### PR TITLE
Adding dependency to ensure build with exrm works

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,7 @@ defmodule Goth.Mixfile do
   def application do
     [
       mod: {Goth, []},
-      applications: [:logger, :httpoison]
+      applications: [:json_web_token, :logger, :httpoison]
     ]
   end
 


### PR DESCRIPTION
A build with mix release will crash without this dependency.

```elixir
%UndefinedFunctionError{arity: 1, function: :private_key, module: JsonWebToken.Algorithm.RsaUtil, reason: nil}`
```