### PR TITLE
Treat expired tokens as missing

### DIFF
--- a/test/goth/token_store_test.exs
+++ b/test/goth/token_store_test.exs
@@ -35,4 +35,12 @@ defmodule Goth.TokenStoreTest do
     assert_receive {:DOWN, ^ref, :process, _, :normal}, 1000
     assert {:ok, %Token{token: "fresh"}} = TokenStore.find("refresh-me")
   end
+
+  # Edge case, should be refreshed automatically but on dev machines
+  # which go to sleep, it is not always happeneing
+  test "find never returns stale tokens", %{bypass: bypass} do
+    token = %Token{scope: "expired", token: "stale", type: "Bearer", expires: 1}
+    {:ok, pid} = GenServer.start_link(Goth.TokenStore,%{"expired" => token})
+    assert :error = TokenStore.find("expired")
+  end
 end


### PR DESCRIPTION
Sometimes (at least happens on dev machines which go to _sleep_), the tokens are not being automatically refreshed (probably because the erlang time lags behind the os time, and also because `:timer.apply_after` only guarantees "not sooner than", but can be much later), which causes authentication issues.

This commit checks the `expires` value against the OS time and, if the token (although present on the `TokenStore`) has expired, it is removed and an `:error` is returned (same as if it were missing). This will cause a new token to be requested.