### PR TITLE
Instruct users to use space delimited scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ A simple library to generate and retrieve Oauth2 tokens for use with Google Clou
 ## Usage
 
 ### Retrieve a token:
-Call `Token.for_scope/1` passing in a string of scopes, separated by a comma:
+Call `Token.for_scope/1` passing in a string of scopes, separated by a space:
 ```elixir
 alias Goth.Token
 {:ok, token} = Token.for_scope("https://www.googleapis.com/auth/pubsub")

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -41,7 +41,7 @@ defmodule Goth.Token do
 
   @doc """
   Get a `%Goth.Token{}` for a particular `scope`. `scope` can be a single
-  scope or multiple scopes joined by a comma.
+  scope or multiple scopes joined by a space.
 
   ## Example
       iex> Token.for_scope("https://www.googleapis.com/auth/pubsub")


### PR DESCRIPTION
As per https://developers.google.com/identity/protocols/OAuth2ServiceAccount#callinganapi