### PR TITLE
Support for Google Cloud Platform metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Goth
 Google + Auth = Goth
 
-A simple library to generate and retrieve Oauth2 tokens for use with Google Cloud Service accounts.
+A simple library to generate and retrieve OAuth2 tokens for use with Google Cloud Service accounts.
+
+It can either retrieve tokens using service account credentials or from Google's metadata service for applications running on Google Cloud Platform.
 
 ## Installation
 
@@ -24,6 +26,8 @@ A simple library to generate and retrieve Oauth2 tokens for use with Google Clou
   config :goth,
     json: "path/to/google/json/creds.json" |> File.read!
   ```
+
+You can skip the last step if your application will run on a GCP or GKE instance with appropriate permissions.
 
 ## Usage
 

--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -3,7 +3,7 @@ defmodule Goth.Client do
   alias Goth.Token
 
   def get_access_token(scope) do
-    token_source = Application.get_env(:goth, :token_source, :metadata)
+    {:ok, token_source} = Config.get(:token_source)
     get_access_token(token_source, scope)
   end
 

--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -74,4 +74,14 @@ defmodule Goth.Client do
     |> String.split(" ")
     |> Enum.all?(fn(scope) -> Enum.member?(scopes, scope) end)
   end
+
+  @doc "Retrieves the project ID from Google's metadata service"
+  def retrieve_metadata_project do
+    headers  = [{"Metadata-Flavor", "Google"}]
+    endpoint = "computeMetadata/v1/project/project-id"
+    metadata = Application.get_env(:goth, :metadata_url,
+      "http://metadata.google.internal")
+    url      = "#{metadata}/#{endpoint}"
+    HTTPoison.get!(url, headers).body
+  end
 end

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -7,9 +7,16 @@ defmodule Goth.Config do
 
   def init(:ok) do
     case Application.get_env(:goth, :json) do
-      nil  -> {:ok, Application.get_env(:goth, :config, %{})}
-      json -> {:ok, Poison.decode!(json)}
+      nil  -> {:ok, Application.get_env(:goth, :config,
+                %{"token_source" => :metadata})}
+      json -> {:ok, decode_json(json)}
     end
+  end
+
+  # Decodes JSON (if configured) and sets oauth token source
+  defp decode_json(json) do
+    Poison.decode!(json)
+    |> Map.put("token_source", :oauth)
   end
 
   def set(key, value) when is_atom(key), do: key |> to_string |> set(value)

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -1,5 +1,6 @@
 defmodule Goth.Config do
   use GenServer
+  alias Goth.Client
 
   def start_link do
     GenServer.start_link(__MODULE__, :ok, [name: __MODULE__])
@@ -8,7 +9,8 @@ defmodule Goth.Config do
   def init(:ok) do
     case Application.get_env(:goth, :json) do
       nil  -> {:ok, Application.get_env(:goth, :config,
-                %{"token_source" => :metadata})}
+                %{"token_source" => :metadata,
+                  "project_id" => Client.retrieve_metadata_project()})}
       json -> {:ok, decode_json(json)}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,9 +10,6 @@ defmodule Goth.Mixfile do
      deps: deps]
   end
 
-  # Configuration for the OTP application
-  #
-  # Type "mix help compile.app" for more information
   def application do
     [
       mod: {Goth, []},
@@ -20,15 +17,6 @@ defmodule Goth.Mixfile do
     ]
   end
 
-  # Dependencies can be Hex packages:
-  #
-  #   {:mydep, "~> 0.3.0"}
-  #
-  # Or git/path repositories:
-  #
-  #   {:mydep, git: "https://github.com/elixir-lang/mydep.git", tag: "0.1.0"}
-  #
-  # Type "mix help deps" for more examples and options
   defp deps do
     [{:json_web_token, "~> 0.2.5"},
      {:httpoison, "~> 0.8.0"},

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule Goth.Mixfile do
 
   def project do
     [app: :goth,
-     version: "0.1.3",
+     version: "0.1.4",
      description: description,
      package: package,
      elixir: "~> 1.2",

--- a/mix.exs
+++ b/mix.exs
@@ -7,8 +7,6 @@ defmodule Goth.Mixfile do
      description: description,
      package: package,
      elixir: "~> 1.2",
-     build_embedded: Mix.env == :prod,
-     start_permanent: Mix.env == :prod,
      deps: deps]
   end
 

--- a/test/goth/client_test.exs
+++ b/test/goth/client_test.exs
@@ -53,7 +53,7 @@ defmodule Goth.ClientTest do
 
     at = token_response["access_token"]
     tt = token_response["token_type"]
-    
+
     assert %Token{token: ^at, type: ^tt, expires: _exp} = data
   end
 

--- a/test/goth/client_test.exs
+++ b/test/goth/client_test.exs
@@ -80,8 +80,8 @@ defmodule Goth.ClientTest do
       uri = "/computeMetadata/v1/instance/service-accounts/default/token"
       assert(uri == conn.request_path, "Default account token should be requested")
       assert(conn.method == "GET", "Request method should be GET")
-      # assert(Plug.Conn.get_req_header(conn, "metadata-flavor") == "Google",
-      #        "Metadata header should be set correctly")
+      assert(Plug.Conn.get_req_header(conn, "metadata-flavor") == ["Google"],
+             "Metadata header should be set correctly")
       Plug.Conn.resp(conn, 200, Poison.encode!(token_response))
     end)
 

--- a/test/goth/config_test.exs
+++ b/test/goth/config_test.exs
@@ -23,4 +23,8 @@ defmodule Goth.ConfigTest do
       assert {:ok, state[key]} == Config.get(key)
     end)
   end
+
+  test "the initial state has the token_source set to oauth" do
+    assert {:ok, :oauth} == Config.get(:token_source)
+  end
 end

--- a/test/goth/config_test.exs
+++ b/test/goth/config_test.exs
@@ -2,6 +2,13 @@ defmodule Goth.ConfigTest do
   use ExUnit.Case
   alias Goth.Config
 
+  setup do
+    bypass = Bypass.open
+    bypass_url = "http://localhost:#{bypass.port}"
+    Application.put_env(:goth, :metadata_url, bypass_url)
+    {:ok, bypass: bypass}
+  end
+
   test "setting and retrieving value" do
     Config.set(:key, "123")
     assert {:ok, "123"} == Config.get(:key)
@@ -26,5 +33,32 @@ defmodule Goth.ConfigTest do
 
   test "the initial state has the token_source set to oauth" do
     assert {:ok, :oauth} == Config.get(:token_source)
+  end
+
+  test "Goth correctly retrieves project IDs from metadata", %{bypass: bypass} do
+    # The test configuration sets an example JSON blob. We override it briefly
+    # during this test.
+    current_json = Application.get_env(:goth, :json)
+    Application.put_env(:goth, :json, nil, persistent: true)
+    Application.stop(:goth)
+
+    # Fake project response
+    project = "test-project"
+    Bypass.expect(bypass, fn(conn) ->
+      uri = "/computeMetadata/v1/project/project-id"
+      assert(conn.request_path == uri, "Goth should ask for project ID")
+      Plug.Conn.resp(conn, 200, project)
+    end)
+    Application.start(:goth)
+
+    assert({:ok, :metadata} == Config.get(:token_source),
+      "Token source should be Google Cloud metadata")
+    assert({:ok, "test-project"} == Config.get(:project_id),
+      "Config should return project from metadata")
+
+    # Restore original config
+    Application.put_env(:goth, :json, current_json, persistent: true)
+    Application.stop(:goth)
+    Application.start(:goth)
   end
 end

--- a/test/goth/token_store_test.exs
+++ b/test/goth/token_store_test.exs
@@ -6,6 +6,7 @@ defmodule Goth.TokenStoreTest do
   setup do
     bypass = Bypass.open
     Application.put_env(:goth, :endpoint, "http://localhost:#{bypass.port}")
+    Application.put_env(:goth, :token_source, :oauth)
     {:ok, bypass: bypass}
   end
 

--- a/test/goth/token_store_test.exs
+++ b/test/goth/token_store_test.exs
@@ -39,9 +39,9 @@ defmodule Goth.TokenStoreTest do
 
   # Edge case, should be refreshed automatically but on dev machines
   # which go to sleep, it is not always happeneing
-  test "find never returns stale tokens", %{bypass: bypass} do
+  test "find never returns stale tokens", %{bypass: _bypass} do
     token = %Token{scope: "expired", token: "stale", type: "Bearer", expires: 1}
-    {:ok, pid} = GenServer.start_link(Goth.TokenStore,%{"expired" => token})
+    {:ok, _pid} = GenServer.start_link(Goth.TokenStore,%{"expired" => token})
     assert :error = TokenStore.find("expired")
   end
 end

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -5,6 +5,7 @@ defmodule Goth.TokenTest do
   setup do
     bypass = Bypass.open
     Application.put_env(:goth, :endpoint, "http://localhost:#{bypass.port}")
+    Application.put_env(:goth, :token_source, :oauth)
     {:ok, bypass: bypass}
   end
 


### PR DESCRIPTION
Applications running on Google Cloud Platform can transparently request tokens from the metadata service, if the instance they are running on has appropriate permissions.

This change makes Goth compatible with token retrieval through the metadata service. Existing configuration does not need to be changed, as the presence of the `:json` key will automatically cause retrieval to use the standard OAuth token provider instead.

Scopes are not currently checked for tokens from the metadata service, however this should be trivial to add by comparing with the output of the `/scopes` endpoint. I just haven't had the time yet!

Other notes:

* Some minor cleanups for readability - highly subjective!
* I removed the Config process. The setter functionality didn't seem to be in use and it provided no extra use besides being a moving part. Let me know if I missed something here.