### PR TITLE
Return errors when API calls fail

### DIFF
--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -51,7 +51,11 @@ defmodule Goth.Client do
     headers  = [{"Content-Type", "application/x-www-form-urlencoded"}]
 
     {:ok, response} = HTTPoison.post(url, body, headers)
-    {:ok, Token.from_response_json(scope, response.body)}
+    if response.status_code >= 200 && response.status_code < 300 do
+      {:ok, Token.from_response_json(scope, response.body)}
+    else
+      {:error, "Could not retrieve token, response: #{response.body}"}
+    end
   end
 
   def claims(scope), do: claims(scope, :os.system_time(:seconds))

--- a/test/goth/client_test.exs
+++ b/test/goth/client_test.exs
@@ -102,4 +102,26 @@ defmodule Goth.ClientTest do
     assert(%Token{token: ^at, type: ^tt, expires: _exp} = data,
            "Returned token should match metadata response")
   end
+
+  test "When authentication fail, warn the user of the issue", %{bypass: bypass} do
+    token_response = %{
+      "error" => "deleted_client",
+      "error_description" => "The OAuth client was deleted."
+    }
+
+    scope = "prediction"
+
+    Bypass.expect bypass, fn conn ->
+      assert "/oauth2/v4/token" == conn.request_path
+      assert "POST"             == conn.method
+
+      assert_body_is_legit_jwt(conn, scope)
+
+      Plug.Conn.resp(conn, 401, Poison.encode!(token_response))
+    end
+
+    {:error, data} = Client.get_access_token(scope)
+
+    assert data =~ "Could not retrieve token, response:"
+  end
 end


### PR DESCRIPTION
When an api fails, let's say the client is deleted, or other various reasons, the current implementation is pretty vague on the reason why the token fetch fails, it would display something like `** (ArithmeticError) bad argument in arithmetic expression`.

My implementation is not perfect since it does treat each error use cases but it's a bit more explanatory.