### PR TITLE
Fetch config in handle_info instead of init

### DIFF
--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -103,9 +103,12 @@ defmodule Goth.Client do
   def retrieve_metadata_project do
     headers  = [{"Metadata-Flavor", "Google"}]
     endpoint = "computeMetadata/v1/project/project-id"
-    metadata = Application.get_env(:goth, :metadata_url,
-      "http://metadata.google.internal")
-    url      = "#{metadata}/#{endpoint}"
-    HTTPoison.get!(url, headers).body
+
+    case Application.get_env(:goth, :metadata_url) do
+      metadata when is_binary(metadata) ->
+        url = "#{metadata}/#{endpoint}"
+        HTTPoison.get!(url, headers).body
+      _ -> %{}
+    end
   end
 end

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -26,12 +26,9 @@ defmodule Goth.Config do
   end
 
   def handle_info(:after_init, _state) do
-    case Application.get_env(:goth, :json) do
-      nil  -> {:noreply, Application.get_env(:goth, :config,
-                %{"token_source" => :metadata,
-                  "project_id" => Client.retrieve_metadata_project()})}
-      {:system, var} -> {:noreply, decode_json(System.get_env(var)) }
-      json -> {:noreply, decode_json(json)}
+    case Application.get_env(:goth, :json_path) do
+      nil -> {:noreply, %{}}
+      path -> {:noreply, path |> File.read!() |> decode_json()}
     end
   end
 

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -21,12 +21,17 @@ defmodule Goth.Config do
   end
 
   def init(:ok) do
+    send(self(), :after_init)
+    {:ok, %{}}
+  end
+
+  def handle_info(:after_init, _state) do
     case Application.get_env(:goth, :json) do
-      nil  -> {:ok, Application.get_env(:goth, :config,
+      nil  -> {:noreply, Application.get_env(:goth, :config,
                 %{"token_source" => :metadata,
                   "project_id" => Client.retrieve_metadata_project()})}
-      {:system, var} -> {:ok, decode_json(System.get_env(var)) }
-      json -> {:ok, decode_json(json)}
+      {:system, var} -> {:noreply, decode_json(System.get_env(var)) }
+      json -> {:noreply, decode_json(json)}
     end
   end
 


### PR DESCRIPTION
If the config is not set, starting the `Config` genserver will fail right now. Because it's started when the application start, the whole startup process fill fail because of this. 


This causes the whole application will fail if goth is added as dependency and the config is not set. This is inconvenient when you want to use it in tests, when it's not really used. 


After this change, `Config` can start even if the config is not set and this fixes the issue.