### PR TITLE
new env variable from spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,13 +29,13 @@ It can either retrieve tokens using service account credentials or from Google's
     json: "path/to/google/json/creds.json" |> File.read!
   ```
 
-  Or, via an ENV var:
+  Or, via "GCP_CREDENTIALS" ENV var:
   ```elixir
   config :goth, json: {:system, "GCP_CREDENTIALS"}
   # where GCP_CREDENTIALS is the contents of the JSON credentials file
   ```
 
-  Or, via an "GOOGLE_APPLICATION_CREDENTIALS" ENV var:
+  Or, via "GOOGLE_APPLICATION_CREDENTIALS" ENV var:
   ```elixir
   config :goth, json: {:system, "GOOGLE_APPLICATION_CREDENTIALS"}
   # where GOOGLE_APPLICATION_CREDENTIALS is the path to JSON credentials file

--- a/README.md
+++ b/README.md
@@ -28,11 +28,19 @@ It can either retrieve tokens using service account credentials or from Google's
   config :goth,
     json: "path/to/google/json/creds.json" |> File.read!
   ```
-  
+
   Or, via an ENV var:
   ```elixir
   config :goth, json: {:system, "GCP_CREDENTIALS"}
+  # where GCP_CREDENTIALS is the contents of the JSON credentials file
   ```
+
+  Or, via an "GOOGLE_APPLICATION_CREDENTIALS" ENV var:
+  ```elixir
+  config :goth, json: {:system, "GOOGLE_APPLICATION_CREDENTIALS"}
+  # where GOOGLE_APPLICATION_CREDENTIALS is the path to JSON credentials file
+  ```
+
 
 You can skip the last step if your application will run on a GCP or GKE instance with appropriate permissions.
 

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -25,6 +25,10 @@ defmodule Goth.Config do
       nil  -> {:ok, Application.get_env(:goth, :config,
                 %{"token_source" => :metadata,
                   "project_id" => Client.retrieve_metadata_project()})}
+      {:system, "GOOGLE_APPLICATION_CREDENTIALS"} ->
+        # according to spec here: https://developers.google.com/identity/protocols/application-default-credentials
+        # "How the Application Default Credentials work", point 1. section g.
+        {:ok, System.get_env("GOOGLE_APPLICATION_CREDENTIALS") |> File.read!() |> decode_json()}
       {:system, var} -> {:ok, decode_json(System.get_env(var)) }
       json -> {:ok, decode_json(json)}
     end


### PR DESCRIPTION
Added possibility to read JSON credentials from the ENV variable which points to JSON credentials file stored locally. This added flexibility for setting up different key files for different servers