### PR TITLE
Allow for the project_id to be overridden manually

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -2,5 +2,3 @@ use Mix.Config
 
 config :goth,
   json: "config/test-credentials.json" |> Path.expand |> File.read!
-
-# config :bypass, enable_debug_log: true

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -21,12 +21,26 @@ defmodule Goth.Config do
   end
 
   def init(:ok) do
-    case Application.get_env(:goth, :json) do
-      nil  -> {:ok, Application.get_env(:goth, :config,
-                %{"token_source" => :metadata,
-                  "project_id" => Client.retrieve_metadata_project()})}
-      {:system, var} -> {:ok, decode_json(System.get_env(var)) }
-      json -> {:ok, decode_json(json)}
+    config =
+      case Application.get_env(:goth, :json) do
+        nil  ->
+          Application.get_env(:goth, :config,
+            %{"token_source" => :metadata,
+              "project_id" => Client.retrieve_metadata_project()
+            })
+        {:system, var} -> decode_json(System.get_env(var))
+        json           -> decode_json(json)
+      end
+
+    {:ok, overrides(config)}
+  end
+
+  # for now, we only allow overriding the project_id
+  defp overrides(config) do
+    case Application.get_env(:goth, :project_id) do
+      nil            -> config
+      {:system, var} -> Map.put(config, "project_id", System.get_env(var))
+      p              -> Map.put(config, "project_id", p)
     end
   end
 

--- a/test/goth/config_test.exs
+++ b/test/goth/config_test.exs
@@ -61,4 +61,17 @@ defmodule Goth.ConfigTest do
     Application.stop(:goth)
     Application.start(:goth)
   end
+
+  test "config can be overriden manually" do
+    project = "different"
+    Application.put_env(:goth, :project_id, project, persistent: true)
+    Application.stop(:goth)
+
+    Application.start(:goth)
+    assert {:ok, ^project} = Config.get(:project_id)
+
+    Application.put_env(:goth, :project_id, nil, persistent: true)
+    Application.stop(:goth)
+    Application.start(:goth)
+  end
 end


### PR DESCRIPTION
Google permissions can work in a very strange (kinda magic?) way where a service account can be given permissions in a project to which is does not actually belong. In order to support this, we need to allow for the project_id to be manually overridden in the config (instead of always reading it from the credentials json).