### PR TITLE
Honor credentials from gcloud application defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 erl_crash.dump
 *.ez
 /config/*credentials*
-!/config/test-credentials.json

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,7 @@
 use Mix.Config
 
 config :goth,
-  json: "config/test-credentials.json" |> Path.expand |> File.read!
+  json: "test/data/test-credentials.json" |> Path.expand |> File.read!
+config :goth, config_root_dir: "test/missing"
 
 # config :bypass, enable_debug_log: true

--- a/test/data/home/gcloud/application_default_credentials.json
+++ b/test/data/home/gcloud/application_default_credentials.json
@@ -1,0 +1,6 @@
+{
+  "type": "authorized_user",
+  "client_id": "blahblahblah.apps.googleusercontent.com",
+  "client_secret": "secretsecretsecret",
+  "refresh_token": "refreshrefreshrefresh"
+}

--- a/test/data/test-credentials-2.json
+++ b/test/data/test-credentials-2.json
@@ -1,0 +1,12 @@
+{
+  "type": "service_account",
+  "project_id": "my-project",
+  "private_key_id": "12345abcde",
+  "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCN1IUO2QhgdI+Q\nUTIWV9X7Gm9Cw6kPgHeZ+f+RXXknSL6/CAwVz1EG2VIgCBJv45mF0Vsw2vM8/0Sx\nSDoEb7skelCahYCQUOIp72egAk3InOINGo/n+A1ai7fmR0EzQ6WFr3pZmzcX/7ZB\n0TjDkXX81NJIreJSfqSCvMg7uZfzihv7RbmljyofxoXwP8FoMOS5BcHo8ZkBZyJx\ny0uLKrFvCkTRS/OhuGRVcJC6VrZUA2MhQPkqjHNcttEXIajL+jl4jmVQ8irwR4LO\nXnFaBoEXexciTAteO4vjrrV2iIh0x24vgD2SemhUW/pOTZ/AMNUjwjnvmWFdvvyf\nFYDTtHL1AgMBAAECggEBAILyYBchUpabh6EbFj+CwVGhSnA97e0eE07afpdb0evv\nQg1mBKJuUsUcCLMCQOOFI81lSeiFfmYm2OlFYiuObR50v86qy9RymR1WqDoXZnF+\nR0cJ6yuk3c9niFbYGt6V6lDPfwsUP32s3j1OSjZmKqVQaQYpZPf9bS431jcuV5jF\n0tJEFZTY+FS3BW3JefpDCBW1SmyXtA4BiZdP37I9hKOohC7iQuOna5g9iaCbFKC4\nw80FZngDB4MTpSypjYBOR4SROOcIMd3cXyDJEuYoJqKpc3Ke9QZrHPSZPKREug7u\nG7v5TwFXwn2lLtlV7KXAknl2CUNGHEzDOyMRP0PVZtECgYEA9ywGoPFP2ejMVJ+e\nvsSo5x5mXL0hczYyUT1ryohi1+4Rq4S4StfvLKZ9hKp8xzOOwChV0QNT6ZdLTOQo\nSQWQ0tqZfzIVOBFxeqRPokaojQ0MEvXcDTnUzCSh7q+GvNFkN5kMcOCaPYGsCWzU\np/BYjyijX/SB3Y/vWCIlRWQpQx8CgYEAkuVRtn5nOwlWcykRE/PYZo9HNPcjdW2Q\nAIki1ntfHZTikLRf3cRpWYgWqbYJMiTq4Mkwhye0jgKRVs8urHJwVxYTXyfPl6UM\n17DaCwnX2VuMDEM9cbBxF4MdbIBuQ7YJUmajrh63E/hx2NJso6/nvYk5V4v5v5lZ\nwTKB+7+a+2sCgYEAoWeSfI6YAkhPBgOl+hUZ5rKnTXAD4+REP2DIft1JDpBb4ZEt\nd1JC0Pl3haZ/DOXSFhFA2Ng/d45gkbl7xRNpWwd8rN7blF1vqRKbHfDeKB2ZANij\n9c8J8rUJOYBNkAd8VgIPabaBgiCnYxA6XeBJNFLpPMPB+hj/xqGljQa3GykCgYAo\nLyNTUPDcbYmAp1NMqgAgzkEkdBb3IKmr+9fT5Jv4c6om+7Dd8cUAAQJyGqIZXZAD\nPgZQcsQptPodTT/vXL7uk9NozHM1gKkqt+5t5pttkmWVVS+R0jqdu/honhmL3Fhg\nekN8dlqO1AAQ2D9v58b1SnytPlVr3H95Il/8hkXXUQKBgDvylw5n2rW4ER2j91Lg\nW74L2D9VXIFp8Trrb+QE5G87GQDXq+WaixEScC0tdOV1MnOHQFRLbMzXQcuf34uu\nLu1yTECyOrRwI2tDcCCnNXQx+e10lGhf8sbWTR9jNjWX5QIBiGdOIq7CV8174IuH\nI7pFKB+yxZJd4tT/F4IbrUBU\n-----END PRIVATE KEY-----\n",
+  "client_email": "test-credentials-2@my-project.iam.gserviceaccount.com",
+  "client_id": "12345",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://accounts.google.com/o/oauth2/token",
+  "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testing-private-key-encryption%40my-project.iam.gserviceaccount.com"
+}

--- a/test/data/test-credentials.json
+++ b/test/data/test-credentials.json
@@ -1,12 +1,12 @@
 {
   "type": "service_account",
-  "project_id": "tokyo-amphora-437",
-  "private_key_id": "854414a51270519ed74ec9112389e495eec1ccd1",
+  "project_id": "my-project",
+  "private_key_id": "12345abcde",
   "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCN1IUO2QhgdI+Q\nUTIWV9X7Gm9Cw6kPgHeZ+f+RXXknSL6/CAwVz1EG2VIgCBJv45mF0Vsw2vM8/0Sx\nSDoEb7skelCahYCQUOIp72egAk3InOINGo/n+A1ai7fmR0EzQ6WFr3pZmzcX/7ZB\n0TjDkXX81NJIreJSfqSCvMg7uZfzihv7RbmljyofxoXwP8FoMOS5BcHo8ZkBZyJx\ny0uLKrFvCkTRS/OhuGRVcJC6VrZUA2MhQPkqjHNcttEXIajL+jl4jmVQ8irwR4LO\nXnFaBoEXexciTAteO4vjrrV2iIh0x24vgD2SemhUW/pOTZ/AMNUjwjnvmWFdvvyf\nFYDTtHL1AgMBAAECggEBAILyYBchUpabh6EbFj+CwVGhSnA97e0eE07afpdb0evv\nQg1mBKJuUsUcCLMCQOOFI81lSeiFfmYm2OlFYiuObR50v86qy9RymR1WqDoXZnF+\nR0cJ6yuk3c9niFbYGt6V6lDPfwsUP32s3j1OSjZmKqVQaQYpZPf9bS431jcuV5jF\n0tJEFZTY+FS3BW3JefpDCBW1SmyXtA4BiZdP37I9hKOohC7iQuOna5g9iaCbFKC4\nw80FZngDB4MTpSypjYBOR4SROOcIMd3cXyDJEuYoJqKpc3Ke9QZrHPSZPKREug7u\nG7v5TwFXwn2lLtlV7KXAknl2CUNGHEzDOyMRP0PVZtECgYEA9ywGoPFP2ejMVJ+e\nvsSo5x5mXL0hczYyUT1ryohi1+4Rq4S4StfvLKZ9hKp8xzOOwChV0QNT6ZdLTOQo\nSQWQ0tqZfzIVOBFxeqRPokaojQ0MEvXcDTnUzCSh7q+GvNFkN5kMcOCaPYGsCWzU\np/BYjyijX/SB3Y/vWCIlRWQpQx8CgYEAkuVRtn5nOwlWcykRE/PYZo9HNPcjdW2Q\nAIki1ntfHZTikLRf3cRpWYgWqbYJMiTq4Mkwhye0jgKRVs8urHJwVxYTXyfPl6UM\n17DaCwnX2VuMDEM9cbBxF4MdbIBuQ7YJUmajrh63E/hx2NJso6/nvYk5V4v5v5lZ\nwTKB+7+a+2sCgYEAoWeSfI6YAkhPBgOl+hUZ5rKnTXAD4+REP2DIft1JDpBb4ZEt\nd1JC0Pl3haZ/DOXSFhFA2Ng/d45gkbl7xRNpWwd8rN7blF1vqRKbHfDeKB2ZANij\n9c8J8rUJOYBNkAd8VgIPabaBgiCnYxA6XeBJNFLpPMPB+hj/xqGljQa3GykCgYAo\nLyNTUPDcbYmAp1NMqgAgzkEkdBb3IKmr+9fT5Jv4c6om+7Dd8cUAAQJyGqIZXZAD\nPgZQcsQptPodTT/vXL7uk9NozHM1gKkqt+5t5pttkmWVVS+R0jqdu/honhmL3Fhg\nekN8dlqO1AAQ2D9v58b1SnytPlVr3H95Il/8hkXXUQKBgDvylw5n2rW4ER2j91Lg\nW74L2D9VXIFp8Trrb+QE5G87GQDXq+WaixEScC0tdOV1MnOHQFRLbMzXQcuf34uu\nLu1yTECyOrRwI2tDcCCnNXQx+e10lGhf8sbWTR9jNjWX5QIBiGdOIq7CV8174IuH\nI7pFKB+yxZJd4tT/F4IbrUBU\n-----END PRIVATE KEY-----\n",
-  "client_email": "testing-private-key-encryption@tokyo-amphora-437.iam.gserviceaccount.com",
-  "client_id": "102915290076242385238",
+  "client_email": "test-credentials@my-project.iam.gserviceaccount.com",
+  "client_id": "12345",
   "auth_uri": "https://accounts.google.com/o/oauth2/auth",
   "token_uri": "https://accounts.google.com/o/oauth2/token",
   "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
-  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testing-private-key-encryption%40tokyo-amphora-437.iam.gserviceaccount.com"
+  "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testing-private-key-encryption%40my-project.iam.gserviceaccount.com"
 }


### PR DESCRIPTION
The overall goal here is to complete support for [application default credentials](https://developers.google.com/identity/protocols/application-default-credentials). This PR provides an implementation of the last piece, gcloud sdk credentials provided by `gcloud auth application-default login`.

It involves two general parts:

1. The logic for resolving the configuration in `config.ex` now includes a step looking for a credentials file in the well-known path used by gcloud. This location is `$HOME/.config/gcloud/application_default_credentials.json` on unix systems, but `%APPDATA%\gcloud\application_default_credentials.json` on windows. (I picked up this logic from the [Ruby auth library](https://github.com/google/google-auth-library-ruby.)

2. Gcloud-provided ADCs are in the form of a refresh token rather than a private key. So I had to implement the oauth flow for that case. I defined a new `token_source` value for this case (`:oauth_refresh`, renaming the current `:oauth` to `:oauth_jwt` to avoid confusion), and then made the appropriate call in `client.ex`.

When writing tests for these cases, I had to create two new "test credentials" files. One is a normal private key file but slightly modified to be distinct from the default (so the existing GOOGLE_APPLICATION_CREDENTIALS test can distinguish it). The other is an application default credentials file (which is a refresh_token file) in its proper directory structure. Because there are now three separate files, I moved them out of the config directory and into `test/data` so we wouldn't have to keep whitelisting them in `.gitignore`. I also modified the private key files to remove identifying project info since the tests don't depend on them.

I did some ad-hoc e2e testing using my own gcloud credentials and verifying that `Goth.Token.for_scope` returns a valid token.

One existing caveat. Gcloud application default credentials don't include a project ID in the credentials file—and indeed, AIUI the "project" may not be well-defined anyway since the credentials are based on the user rather than on a project-connected service account. Goth, however, requires that the project be defined somewhere, so using gcloud-provided credentials requires that you specify the project in an environment variable or some other mechanism. One way to make this nicer for users is to pick up the default project (if set) from `gcloud config` but I'm not convinced that's really necessary. Let me know if you have any opinions on that.
