### PR TITLE
Add informative error message when the project ID can't be automatically found

### DIFF
--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -90,7 +90,8 @@ defmodule Goth.Config do
             case e do
               %HTTPoison.Error{reason: :nxdomain} ->
                 raise " Failed to retrieve project data from GCE internal metadata service.
-                   Either you haven't configured your GCP credentials, you aren't running on GCE, or both."
+                   Either you haven't configured your GCP credentials, you aren't running on GCE, or both.
+                   Please see README.md for instructions on configuring your credentials."
 
               _ ->
                 e


### PR DESCRIPTION
I was a bit puzzled by this error:
`* (Mix) Could not start application goth: Goth.start(:normal, []) returned an error: shutdown: failed to start child: Goth.Config
    ** (EXIT) an exception was raised:
        ** (HTTPoison.Error) :nxdomain
...
`
So I added a try-rescue block to catch this `:nxdomain` error and show how to fix it when it occurs.