### PR TITLE
Add support for sub

### DIFF
--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -18,14 +18,16 @@ defmodule Goth.Client do
   retrieve a new token.
   """
 
-  def get_access_token(scope) do
+  def get_access_token(scope), do: get_access_token(scope, [])
+  def get_access_token(scope, opts) when is_binary(scope) and is_list(opts) do
     {:ok, token_source} = Config.get(:token_source)
-    get_access_token(token_source, scope)
+    get_access_token(token_source, scope, opts)
   end
 
+  def get_access_token(source, scope, opts \\ [])
   # Fetch an access token from Google's metadata service for applications running
   # on Google's Cloud platform.
-  def get_access_token(:metadata, scope) do
+  def get_access_token(:metadata, scope, _opts) do
     headers  = [{"Metadata-Flavor", "Google"}]
     account  = Application.get_env(:goth, :metadata_account, "default")
     metadata = Application.get_env(:goth, :metadata_url,
@@ -39,23 +41,24 @@ defmodule Goth.Client do
   end
 
   # Fetch an access token from Google's OAuth service using a JWT
-  def get_access_token(:oauth_jwt, scope) do
+  def get_access_token(:oauth_jwt, scope, opts) do
+    %{sub: sub} = destruct_opts(opts)
     endpoint = Application.get_env(:goth, :endpoint, "https://www.googleapis.com")
     url      = "#{endpoint}/oauth2/v4/token"
     body     = {:form, [grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                        assertion:  jwt(scope)]}
+                        assertion:  jwt(scope, opts)]}
     headers  = [{"Content-Type", "application/x-www-form-urlencoded"}]
 
     {:ok, response} = HTTPoison.post(url, body, headers)
     if response.status_code >= 200 && response.status_code < 300 do
-      {:ok, Token.from_response_json(scope, response.body)}
+      {:ok, Token.from_response_json(scope, sub, response.body)}
     else
       {:error, "Could not retrieve token, response: #{response.body}"}
     end
   end
 
   # Fetch an access token from Google's OAuth service using a refresh token
-  def get_access_token(:oauth_refresh, scope) do
+  def get_access_token(:oauth_refresh, scope, _opts) do
     {:ok, refresh_token} = Config.get(:refresh_token)
     {:ok, client_id} = Config.get(:client_id)
     {:ok, client_secret} = Config.get(:client_secret)
@@ -75,8 +78,10 @@ defmodule Goth.Client do
     end
   end
 
-  def claims(scope), do: claims(scope, :os.system_time(:seconds))
-  def claims(scope, iat) do
+  def claims(scope, opts \\ [])
+  def claims(scope, iat) when is_integer(iat), do: claims(scope, iat: iat)
+  def claims(scope, opts) when is_list(opts) do
+    %{iat: iat, sub: sub} = destruct_opts(opts)
     {:ok, email} = Config.get(:client_email)
     c =
       %{
@@ -86,24 +91,28 @@ defmodule Goth.Client do
         "iat"   => iat,
         "exp"   => iat+10
       }
-    case Config.get(:actor_email) do
-      {:ok, sub} -> Map.put(c, "sub", sub)
-      _ -> c
+
+    if sub do
+      Map.put(c, "sub", sub)
+    else
+      c
     end
   end
 
-  def json(scope), do: json(scope, :os.system_time(:seconds))
-  def json(scope, iat) do
+  def json(scope, opts \\ [])
+  def json(scope, iat) when is_integer(iat), do: json(scope, iat: iat)
+  def json(scope, opts) when is_list(opts) do
     scope
-    |> claims(iat)
+    |> claims(opts)
     |> Poison.encode!
   end
 
-  def jwt(scope), do: jwt(scope, :os.system_time(:seconds))
-  def jwt(scope, iat) do
+  def jwt(scope, opts \\ []) 
+  def jwt(scope, iat) when is_integer(iat), do: jwt(scope, iat: iat)
+  def jwt(scope, opts) when is_list(opts) do
     {:ok, key} = Config.get(:private_key)
     scope
-    |> claims(iat)
+    |> claims(opts)
     |> JsonWebToken.sign(%{alg: "RS256", key: JsonWebToken.Algorithm.RsaUtil.private_key(key)})
   end
 
@@ -115,5 +124,19 @@ defmodule Goth.Client do
       "http://metadata.google.internal")
     url      = "#{metadata}/#{endpoint}"
     HTTPoison.get!(url, headers).body
+  end
+  
+  defp destruct_opts(opts) do
+    defaults = [
+      iat: :os.system_time(:seconds),
+      sub: case Config.get(:actor_email) do
+        {:ok, sub} -> sub
+        _ -> nil
+      end
+    ]
+
+    defaults
+    |> Keyword.merge(opts)
+    |> Enum.into(%{})
   end
 end

--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -6,6 +6,19 @@ defmodule Goth.Client do
   `Goth.Client` is the module through which all interaction with Google's APIs flows.
   For the most part, you probably don't want to use this module directly, but instead
   use the other modules that cache and wrap the underlying API calls.
+
+  ## Available Options
+
+  Additional token attributes are controlled through options. Available values:
+
+  - `iat` - The time the assertion was issued, default to now.
+  - `sub` - The email address of the user for which the application is requesting delegated access.
+    Default values is taken from the config `:actor_email`.
+
+  See
+  [Google's Documentation](https://developers.google.com/identity/protocols/OAuth2ServiceAccount#authorizingrequests)
+  for more details.
+
   """
 
   @doc """
@@ -24,6 +37,7 @@ defmodule Goth.Client do
     get_access_token(token_source, scope, opts)
   end
 
+  @doc false
   def get_access_token(source, scope, opts \\ [])
   # Fetch an access token from Google's metadata service for applications running
   # on Google's Cloud platform.

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -44,6 +44,9 @@ defmodule Goth.Token do
   Get a `%Goth.Token{}` for a particular `scope`. `scope` can be a single
   scope or multiple scopes joined by a space.
 
+  `sub` needs to be specified if impersonation is used to prevent cache
+  leaking between users.
+
   ## Example
       iex> Token.for_scope("https://www.googleapis.com/auth/pubsub")
       {:ok, %Goth.Token{expires: ..., token: "...", type: "..."} }

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -34,10 +34,11 @@ defmodule Goth.Token do
                     token: String.t,
                     type:  String.t,
                     scope: String.t,
+                    sub:   String.t,
                     expires: non_neg_integer
                   }
 
-  defstruct [:token, :type, :scope, :expires]
+  defstruct [:token, :type, :scope, :sub, :expires]
 
   @doc """
   Get a `%Goth.Token{}` for a particular `scope`. `scope` can be a single
@@ -47,10 +48,10 @@ defmodule Goth.Token do
       iex> Token.for_scope("https://www.googleapis.com/auth/pubsub")
       {:ok, %Goth.Token{expires: ..., token: "...", type: "..."} }
   """
-  @spec for_scope(String.t) :: {:ok, t} | :error
-  def for_scope(scope) do
-    case TokenStore.find(scope) do
-      :error       -> retrieve_and_store!(scope)
+  @spec for_scope(String.t, String.t) :: {:ok, t} | :error
+  def for_scope(scope, sub \\ nil) do
+    case TokenStore.find(scope, sub) do
+      :error       -> retrieve_and_store!(scope, sub)
       {:ok, token} -> {:ok, token}
     end
   end
@@ -58,13 +59,14 @@ defmodule Goth.Token do
   @doc """
   Parse a successful JSON response from Google's token API and extract a `%Goth.Token{}`
   """
-  @spec from_response_json(String.t, String.t) :: t
-  def from_response_json(scope, json) do
+  @spec from_response_json(String.t, String.t, String.t) :: t
+  def from_response_json(scope, sub \\ nil, json) do
     {:ok, attrs} = json |> Poison.decode
     %__MODULE__{
       token:   attrs["access_token"],
       type:    attrs["token_type"],
       scope:   scope,
+      sub:     sub,
       expires: :os.system_time(:seconds) + attrs["expires_in"]
     }
   end
@@ -75,8 +77,9 @@ defmodule Goth.Token do
   rarely if ever actually need to call this method manually.
   """
   @spec refresh!(t | String.t) :: {:ok, t}
+  def refresh!(%__MODULE__{scope: scope, sub: sub}), do: refresh!(scope, sub)
   def refresh!(%__MODULE__{scope: scope}), do: refresh!(scope)
-  def refresh!(scope), do: retrieve_and_store!(scope)
+  def refresh!(scope, sub \\ nil), do: retrieve_and_store!(scope, sub)
 
   def queue_for_refresh(%__MODULE__{}=token) do
     diff = token.expires - :os.system_time(:seconds)
@@ -90,9 +93,9 @@ defmodule Goth.Token do
     end
   end
 
-  defp retrieve_and_store!(scope) do
-    {:ok, token} = Client.get_access_token(scope)
-    TokenStore.store(scope, token)
+  defp retrieve_and_store!(scope, sub) do
+    {:ok, token} = Client.get_access_token(scope, sub: sub)
+    TokenStore.store(scope, sub, token)
     {:ok, token}
   end
 end

--- a/lib/goth/token_store.ex
+++ b/lib/goth/token_store.ex
@@ -19,9 +19,10 @@ defmodule Goth.TokenStore do
   to be refreshed ten seconds before its expiration.
   """
   @spec store(Token.t) :: pid
-  def store(%Token{}=token), do: store(token.scope, token)
-  def store(scopes, %Token{} = token) do
-    GenServer.call(__MODULE__, {:store, scopes, token})
+  def store(%Token{}=token), do: store(token.scope, token.sub, token)
+  def store(scopes, %Token{} = token), do: store(scopes, token.sub, token)
+  def store(scopes, sub, %Token{} = token) do
+    GenServer.call(__MODULE__, {:store, {scopes, sub}, token})
   end
 
   @doc ~S"""
@@ -34,28 +35,28 @@ defmodule Goth.TokenStore do
       Goth.TokenStore.store(token)
       {:ok, ^token} = Goth.TokenStore.find(token.scope)
   """
-  @spec find(String.t) :: {:ok, Token.t} | :error
-  def find(scope) do
-    GenServer.call(__MODULE__, {:find, scope})
+  @spec find(String.t, String.t) :: {:ok, Token.t} | :error
+  def find(scope, sub \\ nil) do
+    GenServer.call(__MODULE__, {:find, {scope, sub}})
   end
 
   # when we store a token, we should refresh it later
-  def handle_call({:store, scope, token}, _from, state) do
+  def handle_call({:store, {scope, sub}, token}, _from, state) do
     # this is a race condition when inserting an expired (or about to expire) token...
     pid_or_timer = Token.queue_for_refresh(token)
-    {:reply, pid_or_timer, Map.put(state, scope, token)}
+    {:reply, pid_or_timer, Map.put(state, {scope, sub}, token)}
   end
 
-  def handle_call({:find, scope}, _from, state) do
+  def handle_call({:find, {scope, sub}}, _from, state) do
     state
-    |> Map.fetch(scope)
+    |> Map.fetch({scope, sub})
     |> filter_expired(:os.system_time(:seconds))
-    |> reply(state, scope)
+    |> reply(state, {scope, sub})
   end
 
   defp filter_expired(:error, _), do: :error
   defp filter_expired({:ok, %Goth.Token{expires: expires}}, system_time) when expires < system_time, do: :error
   defp filter_expired(value, _), do: value
-  defp reply(:error, state, scope), do: {:reply, :error, Map.delete(state, scope)}
-  defp reply(value, state, _scope), do: {:reply, value, state}
+  defp reply(:error, state, {scope, sub}), do: {:reply, :error, Map.delete(state, {scope, sub})}
+  defp reply(value, state, _key), do: {:reply, value, state}
 end

--- a/test/goth/client_test.exs
+++ b/test/goth/client_test.exs
@@ -26,6 +26,41 @@ defmodule Goth.ClientTest do
     } = Client.claims(scope)
   end
 
+  test "iat is support in the JWT" do
+    {:ok, email} = Goth.Config.get(:client_email)
+    iat = :os.system_time(:seconds) + 20
+    exp = iat + 10
+    scope = "prediction"
+
+    token = %{
+      "iss"   => email,
+      "scope" => scope,
+      "aud"   => "https://www.googleapis.com/oauth2/v4/token",
+      "iat"   => iat,
+      "exp"   => exp
+    }
+
+    assert token == Client.claims(scope, iat)
+    assert token == Client.claims(scope, iat: iat)
+  end
+
+  test "sub is support in the JWT" do
+    {:ok, email} = Goth.Config.get(:client_email)
+    iat = :os.system_time(:seconds) + 30
+    exp = iat + 10
+    scope = "prediction"
+    sub = "sub@example.com"
+
+    assert %{
+      "iss"   => ^email,
+      "scope" => ^scope,
+      "aud"   => "https://www.googleapis.com/oauth2/v4/token",
+      "iat"   => ^iat,
+      "sub"   => ^sub,
+      "exp"   => ^exp
+    } = Client.claims(scope, iat: iat, sub: sub)
+  end
+
   test "the claims json generated is legit" do
     json = Client.json("prediction")
     assert {:ok, _obj} = Poison.decode(json)


### PR DESCRIPTION
This PR preserves all the existing APIs while adding `sub` support.

In `Token` and `TokenStore`, `sub` is added as an additional parameter in most functions. 

In `Client`, since we need to accommodate `iat`, I introduced `opts`, which can be used for either, or both `iat` and `sub`. The API signature `jwt(scope, iat)` is preserved, however I recommend deprecate them in favor of `jwt(scope, iat: iat)`. This also leaves room for potential other optional fields in the future.

Also wrote tests and docs for it.

Fix #29.