### PR TITLE
Fix dialyzer errors stemming from mis-specced functions with new `sub` parameter

### DIFF
--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -176,7 +176,7 @@ defmodule Goth.Config do
   @doc """
   Retrieve a value from the config.
   """
-  @spec get(String.t | atom :: {:ok, any()} | :error
+  @spec get(String.t | atom) :: {:ok, any()} | :error
   def get(key) when is_atom(key), do: key |> to_string |> get
   def get(key) do
     GenServer.call(__MODULE__, {:get, key})

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -167,7 +167,7 @@ defmodule Goth.Config do
   @doc """
   Set a value in the config.
   """
-  @spec set(String.t | Atom.t, any()) :: :ok
+  @spec set(String.t | atom, any()) :: :ok
   def set(key, value) when is_atom(key), do: key |> to_string |> set(value)
   def set(key, value) do
     GenServer.call(__MODULE__, {:set, key, value})
@@ -176,7 +176,7 @@ defmodule Goth.Config do
   @doc """
   Retrieve a value from the config.
   """
-  @spec get(String.t | Atom.t) :: {:ok, any()} | :error
+  @spec get(String.t | atom :: {:ok, any()} | :error
   def get(key) when is_atom(key), do: key |> to_string |> get
   def get(key) do
     GenServer.call(__MODULE__, {:get, key})

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -34,7 +34,7 @@ defmodule Goth.Token do
                     token: String.t,
                     type:  String.t,
                     scope: String.t,
-                    sub:   String.t,
+                    sub:   String.t | nil,
                     expires: non_neg_integer
                   }
 
@@ -51,7 +51,7 @@ defmodule Goth.Token do
       iex> Token.for_scope("https://www.googleapis.com/auth/pubsub")
       {:ok, %Goth.Token{expires: ..., token: "...", type: "..."} }
   """
-  @spec for_scope(String.t, String.t) :: {:ok, t} | :error
+  @spec for_scope(scope :: String.t, sub :: String.t | nil) :: {:ok, t}
   def for_scope(scope, sub \\ nil) do
     case TokenStore.find(scope, sub) do
       :error       -> retrieve_and_store!(scope, sub)
@@ -62,7 +62,7 @@ defmodule Goth.Token do
   @doc """
   Parse a successful JSON response from Google's token API and extract a `%Goth.Token{}`
   """
-  @spec from_response_json(String.t, String.t, String.t) :: t
+  @spec from_response_json(scope :: String.t, sub :: String.t | nil, json :: String.t) :: t
   def from_response_json(scope, sub \\ nil, json) do
     {:ok, attrs} = json |> Poison.decode
     %__MODULE__{

--- a/lib/goth/token_store.ex
+++ b/lib/goth/token_store.ex
@@ -20,7 +20,9 @@ defmodule Goth.TokenStore do
   """
   @spec store(Token.t) :: pid
   def store(%Token{}=token), do: store(token.scope, token.sub, token)
+  @spec store(scopes :: String.t, token :: Token.t) :: pid
   def store(scopes, %Token{} = token), do: store(scopes, token.sub, token)
+  @spec store(scopes :: String.t(), sub :: String.t() | nil, token :: Token.t) :: pid
   def store(scopes, sub, %Token{} = token) do
     GenServer.call(__MODULE__, {:store, {scopes, sub}, token})
   end
@@ -35,7 +37,7 @@ defmodule Goth.TokenStore do
       Goth.TokenStore.store(token)
       {:ok, ^token} = Goth.TokenStore.find(token.scope)
   """
-  @spec find(String.t, String.t) :: {:ok, Token.t} | :error
+  @spec find(scope :: String.t, sub :: String.t | nil) :: {:ok, Token.t} | :error
   def find(scope, sub \\ nil) do
     GenServer.call(__MODULE__, {:find, {scope, sub}})
   end


### PR DESCRIPTION
The new sub parameter for a few of the `Token` functions has a default value of `nil`, but this wasn't reflected in the type spec. This meant that dialyzer simply concluded that the function could never finish and so anything that used these functions simply propagated that.

I noticed this because entire trees of execution in one of our projects were marked as having no local return, so this error bubbles up to the top, making dialyzer effectively useless for whatever uses `Goth .

This also addresses #31