### PR TITLE
TokenStore - Define init/1 required by behaviour GenServer

### DIFF
--- a/lib/goth/token_store.ex
+++ b/lib/goth/token_store.ex
@@ -42,6 +42,10 @@ defmodule Goth.TokenStore do
     GenServer.call(__MODULE__, {:find, {scope, sub}})
   end
 
+  def init(state) do
+    {:ok, state}
+  end
+
   # when we store a token, we should refresh it later
   def handle_call({:store, {scope, sub}, token}, _from, state) do
     # this is a race condition when inserting an expired (or about to expire) token...


### PR DESCRIPTION
Fix for this warning message - 

```ex
warning: function init/1 required by behaviour GenServer is not implemented (in module Goth.TokenStore).

We will inject a default implementation for now:

    def init(args) do
      {:ok, args}
    end

But you want to define your own implementation that converts the arguments given to GenServer.start_link/3 to the server state
```