### PR TITLE
Allow for ingesting multiple SAs from one JSON file. Allow for select…

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It can either retrieve tokens using service account credentials or from Google's
   ```
 
 2. Pass in your credentials json downloaded from your GCE account:
+
   ```elixir
   config :goth,
     json: "path/to/google/json/creds.json" |> File.read!
@@ -26,7 +27,7 @@ It can either retrieve tokens using service account credentials or from Google's
   ```elixir
   config :goth, json: {:system, "GCP_CREDENTIALS"}
   ```
-  
+
   Or, via your own config module:
   ```elixir
   config :goth, config_module: MyConfigMod
@@ -34,12 +35,40 @@ It can either retrieve tokens using service account credentials or from Google's
   ```elixir
   defmodule MyConfigMod do
     use Goth.Config
-    
+
     def init(config) do
       {:ok, Keyword.put(config, :json, System.get_env("MY_GCP_JSON_CREDENTIALS"))}
     end
   end
   ```
+
+You can also use a JSON file containing an array of service accounts to be able to use different identities in your application. Each service
+account will be identified by its ```client_email```, which can be passed to ```Goth.Token.for_scope/1``` to specify which service account to use.
+
+For example, if your JSON file contains the following:
+
+```json
+[
+  {
+    "client_email": "account1@myproject.iam.gserviceaccount.com",
+    ...
+  },
+  {
+    "client_email": "account2@myproject.iam.gserviceaccount.com",
+    ...
+  }
+]
+```
+
+You can use the following to get a token for the second service account:
+
+```elixir
+def get_token do
+  {:ok, token} = Goth.Token.for_scope({
+    "account2@myproject.iam.gserviceaccount.com",
+    "https://www.googleapis.com/auth/cloud-platform.read-only"})
+end
+```
 
 You can skip the last step if your application will run on a GCP or GKE instance with appropriate permissions.
 
@@ -52,9 +81,9 @@ If you need to set the email account to impersonate. For example when using serv
   ```
 
 Alternatively, you can pass your sub email on a per-call basis, for example:
-  
+
   ```elixir
-  Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub", 
+  Goth.Token.for_scope("https://www.googleapis.com/auth/pubsub",
                        "some-email@your-domain.com")
   ```
 

--- a/lib/goth/client.ex
+++ b/lib/goth/client.ex
@@ -9,6 +9,9 @@ defmodule Goth.Client do
 
   ## Available Options
 
+  The first parameter is either the token scopes or a tuple of the service
+  account client email and its scopes.
+
   Additional token attributes are controlled through options. Available values:
 
   - `iat` - The time the assertion was issued, default to now.
@@ -31,62 +34,84 @@ defmodule Goth.Client do
   retrieve a new token.
   """
 
-  def get_access_token(scope), do: get_access_token(scope, [])
+  def get_access_token(scope), do: get_access_token({:default, scope}, [])
+
   def get_access_token(scope, opts) when is_binary(scope) and is_list(opts) do
-    {:ok, token_source} = Config.get(:token_source)
-    get_access_token(token_source, scope, opts)
+    get_access_token({:default, scope}, opts)
+  end
+
+  def get_access_token({account, scope}, opts) when is_binary(scope) and is_list(opts) do
+    {:ok, token_source} = Config.get(account, :token_source)
+    get_access_token(token_source, {account, scope}, opts)
   end
 
   @doc false
-  def get_access_token(source, scope, opts \\ [])
+  def get_access_token(source, info, opts \\ [])
   # Fetch an access token from Google's metadata service for applications running
   # on Google's Cloud platform.
-  def get_access_token(:metadata, scope, _opts) do
-    headers  = [{"Metadata-Flavor", "Google"}]
-    account  = Application.get_env(:goth, :metadata_account, "default")
-    metadata = Application.get_env(:goth, :metadata_url,
-                                   "http://metadata.google.internal")
+  def get_access_token(type, scope, opts) when is_atom(type) and is_binary(scope) do
+    get_access_token(type, {:default, scope}, opts)
+  end
+
+  def get_access_token(:metadata, {service_account, scope}, _opts) do
+    headers = [{"Metadata-Flavor", "Google"}]
+    account = Application.get_env(:goth, :metadata_account, "default")
+    metadata = Application.get_env(:goth, :metadata_url, "http://metadata.google.internal")
     endpoint = "computeMetadata/v1/instance/service-accounts"
     url_base = "#{metadata}/#{endpoint}/#{account}"
 
-    url      = "#{url_base}/token"
+    url = "#{url_base}/token"
     {:ok, token} = HTTPoison.get(url, headers)
-    {:ok, Token.from_response_json(scope, token.body)}
+    {:ok, Token.from_response_json({service_account, scope}, token.body)}
   end
 
   # Fetch an access token from Google's OAuth service using a JWT
-  def get_access_token(:oauth_jwt, scope, opts) do
+  def get_access_token(:oauth_jwt, {account, scope}, opts) do
     %{sub: sub} = destruct_opts(opts)
     endpoint = Application.get_env(:goth, :endpoint, "https://www.googleapis.com")
-    url      = "#{endpoint}/oauth2/v4/token"
-    body     = {:form, [grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
-                        assertion:  jwt(scope, opts)]}
-    headers  = [{"Content-Type", "application/x-www-form-urlencoded"}]
+    url = "#{endpoint}/oauth2/v4/token"
+
+    body =
+      {:form,
+       [
+         grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+         assertion: jwt({account, scope}, opts)
+       ]}
+
+    headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
 
     {:ok, response} = HTTPoison.post(url, body, headers)
+
     if response.status_code >= 200 && response.status_code < 300 do
-      {:ok, Token.from_response_json(scope, sub, response.body)}
+      {:ok, Token.from_response_json({account, scope}, sub, response.body)}
     else
       {:error, "Could not retrieve token, response: #{response.body}"}
     end
   end
 
   # Fetch an access token from Google's OAuth service using a refresh token
-  def get_access_token(:oauth_refresh, scope, _opts) do
+  def get_access_token(:oauth_refresh, {account, scope}, _opts) do
     {:ok, refresh_token} = Config.get(:refresh_token)
     {:ok, client_id} = Config.get(:client_id)
     {:ok, client_secret} = Config.get(:client_secret)
     endpoint = Application.get_env(:goth, :endpoint, "https://www.googleapis.com")
-    url      = "#{endpoint}/oauth2/v4/token"
-    body     = {:form, [grant_type: "refresh_token",
-                        refresh_token: refresh_token,
-                        client_id: client_id,
-                        client_secret: client_secret]}
-    headers  = [{"Content-Type", "application/x-www-form-urlencoded"}]
+    url = "#{endpoint}/oauth2/v4/token"
+
+    body =
+      {:form,
+       [
+         grant_type: "refresh_token",
+         refresh_token: refresh_token,
+         client_id: client_id,
+         client_secret: client_secret
+       ]}
+
+    headers = [{"Content-Type", "application/x-www-form-urlencoded"}]
 
     {:ok, response} = HTTPoison.post(url, body, headers)
+
     if response.status_code >= 200 && response.status_code < 300 do
-      {:ok, Token.from_response_json(scope, response.body)}
+      {:ok, Token.from_response_json({account, scope}, response.body)}
     else
       {:error, "Could not retrieve token, response: #{response.body}"}
     end
@@ -94,17 +119,19 @@ defmodule Goth.Client do
 
   def claims(scope, opts \\ [])
   def claims(scope, iat) when is_integer(iat), do: claims(scope, iat: iat)
-  def claims(scope, opts) when is_list(opts) do
+  def claims(scope, opts) when is_binary(scope), do: claims({:default, scope}, opts)
+
+  def claims({account, scope}, opts) when is_list(opts) do
     %{iat: iat, sub: sub} = destruct_opts(opts)
-    {:ok, email} = Config.get(:client_email)
-    c =
-      %{
-        "iss"   => email,
-        "scope" => scope,
-        "aud"   => "https://www.googleapis.com/oauth2/v4/token",
-        "iat"   => iat,
-        "exp"   => iat+10
-      }
+    {:ok, email} = Config.get(account, :client_email)
+
+    c = %{
+      "iss" => email,
+      "scope" => scope,
+      "aud" => "https://www.googleapis.com/oauth2/v4/token",
+      "iat" => iat,
+      "exp" => iat + 10
+    }
 
     if sub do
       Map.put(c, "sub", sub)
@@ -115,38 +142,41 @@ defmodule Goth.Client do
 
   def json(scope, opts \\ [])
   def json(scope, iat) when is_integer(iat), do: json(scope, iat: iat)
-  def json(scope, opts) when is_list(opts) do
-    scope
-    |> claims(opts)
-    |> Poison.encode!
+  def json(scope, opts) when is_binary(scope), do: json({:default, scope}, opts)
+
+  def json({account, scope}, opts) when is_list(opts) do
+    claims({account, scope}, opts)
+    |> Poison.encode!()
   end
 
-  def jwt(scope, opts \\ []) 
+  def jwt(info, opts \\ [])
   def jwt(scope, iat) when is_integer(iat), do: jwt(scope, iat: iat)
-  def jwt(scope, opts) when is_list(opts) do
-    {:ok, key} = Config.get(:private_key)
-    scope
-    |> claims(opts)
+  def jwt(scope, opts) when is_binary(scope), do: jwt({:default, scope}, opts)
+
+  def jwt({account, scope}, opts) when is_list(opts) do
+    {:ok, key} = Config.get(account, :private_key)
+
+    claims({account, scope}, opts)
     |> JsonWebToken.sign(%{alg: "RS256", key: JsonWebToken.Algorithm.RsaUtil.private_key(key)})
   end
 
   @doc "Retrieves the project ID from Google's metadata service"
   def retrieve_metadata_project do
-    headers  = [{"Metadata-Flavor", "Google"}]
+    headers = [{"Metadata-Flavor", "Google"}]
     endpoint = "computeMetadata/v1/project/project-id"
-    metadata = Application.get_env(:goth, :metadata_url,
-      "http://metadata.google.internal")
-    url      = "#{metadata}/#{endpoint}"
+    metadata = Application.get_env(:goth, :metadata_url, "http://metadata.google.internal")
+    url = "#{metadata}/#{endpoint}"
     HTTPoison.get!(url, headers).body
   end
-  
+
   defp destruct_opts(opts) do
     defaults = [
       iat: :os.system_time(:seconds),
-      sub: case Config.get(:actor_email) do
-        {:ok, sub} -> sub
-        _ -> nil
-      end
+      sub:
+        case Config.get(:actor_email) do
+          {:ok, sub} -> sub
+          _ -> nil
+        end
     ]
 
     defaults

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -17,7 +17,19 @@ defmodule Goth.Token do
       {:ok, %Goth.Token{token: "23984723",
                         type: "Bearer",
                         scope: "https://www.googleapis.com/auth/pubsub",
-                        expires: 1453653825}}
+                        expires: 1453653825,
+                        account: :default}}
+
+  If the passed credentials contain multiple service account, you can change
+  the first parametter to be {client_email, scopes} to specify which account
+  to target.
+
+      iex> Goth.Token.for_scope({"myaccount@project.iam.gserviceaccount.com", "https://www.googleapis.com/auth/pubsub"})
+      {:ok, %Goth.Token{token: "23984723",
+                        type: "Bearer",
+                        scope: "https://www.googleapis.com/auth/pubsub",
+                        expires: 1453653825,
+                        account: "myaccount@project.iam.gserviceaccount.com"}}
 
   For using the token on subsequent requests to the Google API, just concatenate
   the `type` and `token` to create the authorization header. An example using
@@ -31,14 +43,15 @@ defmodule Goth.Token do
   alias Goth.Client
 
   @type t :: %__MODULE__{
-                    token: String.t,
-                    type:  String.t,
-                    scope: String.t,
-                    sub:   String.t | nil,
-                    expires: non_neg_integer
-                  }
+          token: String.t(),
+          type: String.t(),
+          scope: String.t(),
+          sub: String.t() | nil,
+          expires: non_neg_integer,
+          account: String.t()
+        }
 
-  defstruct [:token, :type, :scope, :sub, :expires]
+  defstruct [:token, :type, :scope, :sub, :expires, :account]
 
   @doc """
   Get a `%Goth.Token{}` for a particular `scope`. `scope` can be a single
@@ -51,10 +64,20 @@ defmodule Goth.Token do
       iex> Token.for_scope("https://www.googleapis.com/auth/pubsub")
       {:ok, %Goth.Token{expires: ..., token: "...", type: "..."} }
   """
-  @spec for_scope(scope :: String.t, sub :: String.t | nil) :: {:ok, t}
-  def for_scope(scope, sub \\ nil) do
-    case TokenStore.find(scope, sub) do
-      :error       -> retrieve_and_store!(scope, sub)
+  @spec for_scope(scope :: String.t(), sub :: String.t() | nil) :: {:ok, t}
+  def for_scope(info, sub \\ nil)
+
+  def for_scope(scope, sub) when is_binary(scope) do
+    case TokenStore.find({:default, scope}, sub) do
+      :error -> retrieve_and_store!({:default, scope}, sub)
+      {:ok, token} -> {:ok, token}
+    end
+  end
+
+  @spec for_scope({info :: {String.t(), atom()} | atom()}, sub :: String.t() | nil) :: {:ok, t}
+  def for_scope({account, scope}, sub) do
+    case TokenStore.find({account, scope}, sub) do
+      :error -> retrieve_and_store!({account, scope}, sub)
       {:ok, token} -> {:ok, token}
     end
   end
@@ -62,15 +85,37 @@ defmodule Goth.Token do
   @doc """
   Parse a successful JSON response from Google's token API and extract a `%Goth.Token{}`
   """
-  @spec from_response_json(scope :: String.t, sub :: String.t | nil, json :: String.t) :: t
-  def from_response_json(scope, sub \\ nil, json) do
-    {:ok, attrs} = json |> Poison.decode
+  def from_response_json(scope, sub \\ nil, json)
+
+  @spec from_response_json(String.t(), String.t() | nil, String.t()) :: t
+  def from_response_json(scope, sub, json) when is_binary(scope) do
+    {:ok, attrs} = json |> Poison.decode()
+
     %__MODULE__{
-      token:   attrs["access_token"],
-      type:    attrs["token_type"],
-      scope:   scope,
-      sub:     sub,
-      expires: :os.system_time(:seconds) + attrs["expires_in"]
+      token: attrs["access_token"],
+      type: attrs["token_type"],
+      scope: scope,
+      sub: sub,
+      expires: :os.system_time(:seconds) + attrs["expires_in"],
+      account: :default
+    }
+  end
+
+  @spec from_response_json(
+          {atom() | String.t(), String.t()},
+          String.t() | nil,
+          String.t()
+        ) :: t
+  def from_response_json({account, scope}, sub, json) do
+    {:ok, attrs} = json |> Poison.decode()
+
+    %__MODULE__{
+      token: attrs["access_token"],
+      type: attrs["token_type"],
+      scope: scope,
+      sub: sub,
+      expires: :os.system_time(:seconds) + attrs["expires_in"],
+      account: account
     }
   end
 
@@ -79,26 +124,30 @@ defmodule Goth.Token do
   although `Goth` automatically handles refreshing tokens for you, so you should
   rarely if ever actually need to call this method manually.
   """
-  @spec refresh!(t | String.t) :: {:ok, t}
-  def refresh!(%__MODULE__{scope: scope, sub: sub}), do: refresh!(scope, sub)
-  def refresh!(%__MODULE__{scope: scope}), do: refresh!(scope)
-  def refresh!(scope, sub \\ nil), do: retrieve_and_store!(scope, sub)
+  @spec refresh!(t | String.t()) :: {:ok, t}
+  def refresh!(%__MODULE__{account: account, scope: scope, sub: sub}),
+    do: refresh!({account, scope}, sub)
 
-  def queue_for_refresh(%__MODULE__{}=token) do
+  def refresh!(%__MODULE__{account: account, scope: scope}), do: refresh!({account, scope})
+
+  def refresh!({account, scope}, sub \\ nil), do: retrieve_and_store!({account, scope}, sub)
+
+  def queue_for_refresh(%__MODULE__{} = token) do
     diff = token.expires - :os.system_time(:seconds)
+
     if diff < 10 do
       # just do it immediately
-      Task.async fn ->
+      Task.async(fn ->
         __MODULE__.refresh!(token)
-      end
+      end)
     else
-      :timer.apply_after((diff-10)*1000, __MODULE__, :refresh!, [token])
+      :timer.apply_after((diff - 10) * 1000, __MODULE__, :refresh!, [token])
     end
   end
 
-  defp retrieve_and_store!(scope, sub) do
-    {:ok, token} = Client.get_access_token(scope, sub: sub)
-    TokenStore.store(scope, sub, token)
+  defp retrieve_and_store!({account, scope}, sub) do
+    {:ok, token} = Client.get_access_token({account, scope}, sub: sub)
+    TokenStore.store({account, scope}, sub, token)
     {:ok, token}
   end
 end

--- a/lib/goth/token_store.ex
+++ b/lib/goth/token_store.ex
@@ -11,7 +11,7 @@ defmodule Goth.TokenStore do
   alias Goth.Token
 
   def start_link do
-    GenServer.start_link(__MODULE__, %{}, [name: __MODULE__])
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
   end
 
   def init(state) do
@@ -22,13 +22,24 @@ defmodule Goth.TokenStore do
   Store a token in the `TokenStore`. Upon storage, Goth will queue the token
   to be refreshed ten seconds before its expiration.
   """
-  @spec store(Token.t) :: pid
-  def store(%Token{}=token), do: store(token.scope, token.sub, token)
-  @spec store(scopes :: String.t, token :: Token.t) :: pid
-  def store(scopes, %Token{} = token), do: store(scopes, token.sub, token)
-  @spec store(scopes :: String.t(), sub :: String.t() | nil, token :: Token.t) :: pid
-  def store(scopes, sub, %Token{} = token) do
-    GenServer.call(__MODULE__, {:store, {scopes, sub}, token})
+  @spec store(Token.t()) :: pid
+  def store(%Token{} = token), do: store(token.scope, token.sub, token)
+
+  @spec store(String.t(), Token.t()) :: pid
+  def store(scopes, %Token{} = token) when is_binary(scopes),
+    do: store({:default, scopes}, token.sub, token)
+
+  @spec store(String.t(), String.t(), Token.t()) :: pid
+  def store(scopes, sub, %Token{} = token) when is_binary(scopes),
+    do: store({:default, scopes}, sub, token)
+
+  @spec store({String.t() | atom(), String.t()}, String.t() | nil, Token.t()) :: pid
+  def store({account, scopes}, %Token{} = token) when is_binary(scopes),
+    do: store({account, scopes}, token.sub, token)
+
+  @spec store({String.t() | atom(), String.t()}, String.t() | nil, Token.t()) :: pid
+  def store({account, scopes}, sub, %Token{} = token) when is_binary(scopes) do
+    GenServer.call(__MODULE__, {:store, {account, scopes, sub}, token})
   end
 
   @doc ~S"""
@@ -41,28 +52,40 @@ defmodule Goth.TokenStore do
       Goth.TokenStore.store(token)
       {:ok, ^token} = Goth.TokenStore.find(token.scope)
   """
-  @spec find(scope :: String.t, sub :: String.t | nil) :: {:ok, Token.t} | :error
-  def find(scope, sub \\ nil) do
-    GenServer.call(__MODULE__, {:find, {scope, sub}})
+  @spec find({String.t() | atom(), String.t()} | String.t(), String.t() | nil) ::
+          {:ok, Token.t()} | :error
+  def find(info, sub \\ nil)
+
+  def find(scope, sub) when is_binary(scope), do: find({:default, scope}, sub)
+
+  def find({account, scope}, sub) do
+    GenServer.call(__MODULE__, {:find, {account, scope, sub}})
   end
 
   # when we store a token, we should refresh it later
-  def handle_call({:store, {scope, sub}, token}, _from, state) do
+  def handle_call({:store, {account, scope, sub}, token}, _from, state) do
     # this is a race condition when inserting an expired (or about to expire) token...
     pid_or_timer = Token.queue_for_refresh(token)
-    {:reply, pid_or_timer, Map.put(state, {scope, sub}, token)}
+    {:reply, pid_or_timer, Map.put(state, {account, scope, sub}, token)}
   end
 
-  def handle_call({:find, {scope, sub}}, _from, state) do
+  def handle_call({:find, {account, scope, sub}}, _from, state) do
     state
-    |> Map.fetch({scope, sub})
+    |> Map.fetch({account, scope, sub})
     |> filter_expired(:os.system_time(:seconds))
-    |> reply(state, {scope, sub})
+    |> reply(state, {account, scope, sub})
   end
 
   defp filter_expired(:error, _), do: :error
-  defp filter_expired({:ok, %Goth.Token{expires: expires}}, system_time) when expires < system_time, do: :error
+
+  defp filter_expired({:ok, %Goth.Token{expires: expires}}, system_time)
+       when expires < system_time,
+       do: :error
+
   defp filter_expired(value, _), do: value
-  defp reply(:error, state, {scope, sub}), do: {:reply, :error, Map.delete(state, {scope, sub})}
+
+  defp reply(:error, state, {account, scope, sub}),
+    do: {:reply, :error, Map.delete(state, {account, scope, sub})}
+
   defp reply(value, state, _key), do: {:reply, value, state}
 end

--- a/test/data/test-multicredentials.json
+++ b/test/data/test-multicredentials.json
@@ -1,0 +1,26 @@
+[
+  {
+    "type": "service_account",
+    "project_id": "my-project",
+    "private_key_id": "12345abcde",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCN1IUO2QhgdI+Q\nUTIWV9X7Gm9Cw6kPgHeZ+f+RXXknSL6/CAwVz1EG2VIgCBJv45mF0Vsw2vM8/0Sx\nSDoEb7skelCahYCQUOIp72egAk3InOINGo/n+A1ai7fmR0EzQ6WFr3pZmzcX/7ZB\n0TjDkXX81NJIreJSfqSCvMg7uZfzihv7RbmljyofxoXwP8FoMOS5BcHo8ZkBZyJx\ny0uLKrFvCkTRS/OhuGRVcJC6VrZUA2MhQPkqjHNcttEXIajL+jl4jmVQ8irwR4LO\nXnFaBoEXexciTAteO4vjrrV2iIh0x24vgD2SemhUW/pOTZ/AMNUjwjnvmWFdvvyf\nFYDTtHL1AgMBAAECggEBAILyYBchUpabh6EbFj+CwVGhSnA97e0eE07afpdb0evv\nQg1mBKJuUsUcCLMCQOOFI81lSeiFfmYm2OlFYiuObR50v86qy9RymR1WqDoXZnF+\nR0cJ6yuk3c9niFbYGt6V6lDPfwsUP32s3j1OSjZmKqVQaQYpZPf9bS431jcuV5jF\n0tJEFZTY+FS3BW3JefpDCBW1SmyXtA4BiZdP37I9hKOohC7iQuOna5g9iaCbFKC4\nw80FZngDB4MTpSypjYBOR4SROOcIMd3cXyDJEuYoJqKpc3Ke9QZrHPSZPKREug7u\nG7v5TwFXwn2lLtlV7KXAknl2CUNGHEzDOyMRP0PVZtECgYEA9ywGoPFP2ejMVJ+e\nvsSo5x5mXL0hczYyUT1ryohi1+4Rq4S4StfvLKZ9hKp8xzOOwChV0QNT6ZdLTOQo\nSQWQ0tqZfzIVOBFxeqRPokaojQ0MEvXcDTnUzCSh7q+GvNFkN5kMcOCaPYGsCWzU\np/BYjyijX/SB3Y/vWCIlRWQpQx8CgYEAkuVRtn5nOwlWcykRE/PYZo9HNPcjdW2Q\nAIki1ntfHZTikLRf3cRpWYgWqbYJMiTq4Mkwhye0jgKRVs8urHJwVxYTXyfPl6UM\n17DaCwnX2VuMDEM9cbBxF4MdbIBuQ7YJUmajrh63E/hx2NJso6/nvYk5V4v5v5lZ\nwTKB+7+a+2sCgYEAoWeSfI6YAkhPBgOl+hUZ5rKnTXAD4+REP2DIft1JDpBb4ZEt\nd1JC0Pl3haZ/DOXSFhFA2Ng/d45gkbl7xRNpWwd8rN7blF1vqRKbHfDeKB2ZANij\n9c8J8rUJOYBNkAd8VgIPabaBgiCnYxA6XeBJNFLpPMPB+hj/xqGljQa3GykCgYAo\nLyNTUPDcbYmAp1NMqgAgzkEkdBb3IKmr+9fT5Jv4c6om+7Dd8cUAAQJyGqIZXZAD\nPgZQcsQptPodTT/vXL7uk9NozHM1gKkqt+5t5pttkmWVVS+R0jqdu/honhmL3Fhg\nekN8dlqO1AAQ2D9v58b1SnytPlVr3H95Il/8hkXXUQKBgDvylw5n2rW4ER2j91Lg\nW74L2D9VXIFp8Trrb+QE5G87GQDXq+WaixEScC0tdOV1MnOHQFRLbMzXQcuf34uu\nLu1yTECyOrRwI2tDcCCnNXQx+e10lGhf8sbWTR9jNjWX5QIBiGdOIq7CV8174IuH\nI7pFKB+yxZJd4tT/F4IbrUBU\n-----END PRIVATE KEY-----\n",
+    "client_email": "test-multicredentials-1@my-project.iam.gserviceaccount.com",
+    "client_id": "12345",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testing-private-key-encryption%40my-project.iam.gserviceaccount.com"
+  },
+  {
+    "type": "service_account",
+    "project_id": "my-project",
+    "private_key_id": "12345abcde",
+    "private_key": "-----BEGIN PRIVATE KEY-----\nMIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCN1IUO2QhgdI+Q\nUTIWV9X7Gm9Cw6kPgHeZ+f+RXXknSL6/CAwVz1EG2VIgCBJv45mF0Vsw2vM8/0Sx\nSDoEb7skelCahYCQUOIp72egAk3InOINGo/n+A1ai7fmR0EzQ6WFr3pZmzcX/7ZB\n0TjDkXX81NJIreJSfqSCvMg7uZfzihv7RbmljyofxoXwP8FoMOS5BcHo8ZkBZyJx\ny0uLKrFvCkTRS/OhuGRVcJC6VrZUA2MhQPkqjHNcttEXIajL+jl4jmVQ8irwR4LO\nXnFaBoEXexciTAteO4vjrrV2iIh0x24vgD2SemhUW/pOTZ/AMNUjwjnvmWFdvvyf\nFYDTtHL1AgMBAAECggEBAILyYBchUpabh6EbFj+CwVGhSnA97e0eE07afpdb0evv\nQg1mBKJuUsUcCLMCQOOFI81lSeiFfmYm2OlFYiuObR50v86qy9RymR1WqDoXZnF+\nR0cJ6yuk3c9niFbYGt6V6lDPfwsUP32s3j1OSjZmKqVQaQYpZPf9bS431jcuV5jF\n0tJEFZTY+FS3BW3JefpDCBW1SmyXtA4BiZdP37I9hKOohC7iQuOna5g9iaCbFKC4\nw80FZngDB4MTpSypjYBOR4SROOcIMd3cXyDJEuYoJqKpc3Ke9QZrHPSZPKREug7u\nG7v5TwFXwn2lLtlV7KXAknl2CUNGHEzDOyMRP0PVZtECgYEA9ywGoPFP2ejMVJ+e\nvsSo5x5mXL0hczYyUT1ryohi1+4Rq4S4StfvLKZ9hKp8xzOOwChV0QNT6ZdLTOQo\nSQWQ0tqZfzIVOBFxeqRPokaojQ0MEvXcDTnUzCSh7q+GvNFkN5kMcOCaPYGsCWzU\np/BYjyijX/SB3Y/vWCIlRWQpQx8CgYEAkuVRtn5nOwlWcykRE/PYZo9HNPcjdW2Q\nAIki1ntfHZTikLRf3cRpWYgWqbYJMiTq4Mkwhye0jgKRVs8urHJwVxYTXyfPl6UM\n17DaCwnX2VuMDEM9cbBxF4MdbIBuQ7YJUmajrh63E/hx2NJso6/nvYk5V4v5v5lZ\nwTKB+7+a+2sCgYEAoWeSfI6YAkhPBgOl+hUZ5rKnTXAD4+REP2DIft1JDpBb4ZEt\nd1JC0Pl3haZ/DOXSFhFA2Ng/d45gkbl7xRNpWwd8rN7blF1vqRKbHfDeKB2ZANij\n9c8J8rUJOYBNkAd8VgIPabaBgiCnYxA6XeBJNFLpPMPB+hj/xqGljQa3GykCgYAo\nLyNTUPDcbYmAp1NMqgAgzkEkdBb3IKmr+9fT5Jv4c6om+7Dd8cUAAQJyGqIZXZAD\nPgZQcsQptPodTT/vXL7uk9NozHM1gKkqt+5t5pttkmWVVS+R0jqdu/honhmL3Fhg\nekN8dlqO1AAQ2D9v58b1SnytPlVr3H95Il/8hkXXUQKBgDvylw5n2rW4ER2j91Lg\nW74L2D9VXIFp8Trrb+QE5G87GQDXq+WaixEScC0tdOV1MnOHQFRLbMzXQcuf34uu\nLu1yTECyOrRwI2tDcCCnNXQx+e10lGhf8sbWTR9jNjWX5QIBiGdOIq7CV8174IuH\nI7pFKB+yxZJd4tT/F4IbrUBU\n-----END PRIVATE KEY-----\n",
+    "client_email": "test-multicredentials-2@my-project.iam.gserviceaccount.com",
+    "client_id": "12345",
+    "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+    "token_uri": "https://accounts.google.com/o/oauth2/token",
+    "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+    "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/testing-private-key-encryption%40my-project.iam.gserviceaccount.com"
+  }
+]

--- a/test/goth/token_store_test.exs
+++ b/test/goth/token_store_test.exs
@@ -4,21 +4,46 @@ defmodule Goth.TokenStoreTest do
   alias Goth.Token
 
   setup do
-    bypass = Bypass.open
+    bypass = Bypass.open()
     Application.put_env(:goth, :endpoint, "http://localhost:#{bypass.port}")
     Application.put_env(:goth, :token_source, :oauth)
     {:ok, bypass: bypass}
   end
 
   test "we can store an access token" do
-    TokenStore.store("devstorage.readonly, prediction", %Token{token: "123", type: "Bearer", expires: :os.system_time(:seconds)+1000})
+    TokenStore.store("devstorage.readonly, prediction", %Token{
+      token: "123",
+      type: "Bearer",
+      expires: :os.system_time(:seconds) + 1000
+    })
+
     {:ok, token} = TokenStore.find("devstorage.readonly, prediction")
     assert %Token{token: "123", type: "Bearer"} = token
     assert token.expires > :os.system_time(:seconds) + 900
   end
 
+  test "we can store an acces token for a specific account" do
+    TokenStore.store({"account@example.com", "devstorage.readonly, prediction"}, %Token{
+      token: "123",
+      type: "Bearer",
+      expires: :os.system_time(:seconds) + 1000,
+      account: "account@example.com"
+    })
+
+    {:ok, token} = TokenStore.find({"account@example.com", "devstorage.readonly, prediction"})
+    assert %Token{token: "123", type: "Bearer"} = token
+    assert token.expires > :os.system_time(:seconds) + 900
+  end
+
   test "a token is queued for refresh when stored" do
-    token = %Token{scope: "will-be-stale", token: "stale", type: "Bearer", sub: "sub@example.com", expires: :os.system_time(:seconds)+1000}
+    token = %Token{
+      scope: "will-be-stale",
+      token: "stale",
+      type: "Bearer",
+      sub: "sub@example.com",
+      expires: :os.system_time(:seconds) + 1000,
+      account: :default
+    }
 
     # if queued for later, we'll get back a reference
     {:ok, {_id, ref}} = TokenStore.store(token)
@@ -26,13 +51,28 @@ defmodule Goth.TokenStoreTest do
   end
 
   test "an expired token is refreshed immediately", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "fresh", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{
+          "access_token" => "fresh",
+          "token_type" => "Bearer",
+          "expires_in" => 3600
+        })
+      )
+    end)
 
-    token = %Token{scope: "refresh-me", token: "stale", type: "Bearer", expires: 1}
+    token = %Token{
+      scope: "refresh-me",
+      token: "stale",
+      type: "Bearer",
+      expires: 1,
+      account: :default
+    }
+
     task = TokenStore.store(token)
-    ref  = Process.monitor(task.pid)
+    ref = Process.monitor(task.pid)
     assert_receive {:DOWN, ^ref, :process, _, :normal}, 1000
     assert {:ok, %Token{token: "fresh"}} = TokenStore.find("refresh-me")
   end
@@ -41,13 +81,20 @@ defmodule Goth.TokenStoreTest do
   # which go to sleep, it is not always happeneing
   test "find never returns stale tokens", %{bypass: _bypass} do
     token = %Token{scope: "expired", token: "stale", type: "Bearer", expires: 1}
-    {:ok, _pid} = GenServer.start_link(Goth.TokenStore,%{"expired" => token})
+    {:ok, _pid} = GenServer.start_link(Goth.TokenStore, %{"expired" => token})
     assert :error = TokenStore.find("expired")
   end
 
   test "token can be stored with sub" do
     sub = "sub@example.com"
-    TokenStore.store("devstorage.readonly, prediction", %Token{token: "123", type: "Bearer", sub: sub, expires: :os.system_time(:seconds)+1000})
+
+    TokenStore.store("devstorage.readonly, prediction", %Token{
+      token: "123",
+      type: "Bearer",
+      sub: sub,
+      expires: :os.system_time(:seconds) + 1000
+    })
+
     {:ok, token} = TokenStore.find("devstorage.readonly, prediction", sub)
     assert %Token{token: "123", type: "Bearer", sub: _} = token
     assert token.expires > :os.system_time(:seconds) + 900
@@ -57,11 +104,54 @@ defmodule Goth.TokenStoreTest do
     scopes = "devstorage.readonly, prediction, drive.readonly"
     sub1 = "sub1@example.com"
     sub2 = "sub2@example.com"
-    TokenStore.store(scopes, %Token{token: "123", type: "Bearer", sub: sub1, expires: :os.system_time(:seconds)+1000})
-    TokenStore.store(scopes, %Token{token: "123", type: "Bearer", sub: sub2, expires: :os.system_time(:seconds)+1000})
+
+    TokenStore.store(scopes, %Token{
+      token: "123",
+      type: "Bearer",
+      sub: sub1,
+      expires: :os.system_time(:seconds) + 1000,
+      account: :default
+    })
+
+    TokenStore.store(scopes, %Token{
+      token: "123",
+      type: "Bearer",
+      sub: sub2,
+      expires: :os.system_time(:seconds) + 1000,
+      account: :default
+    })
+
     assert :error == TokenStore.find(scopes)
     {:ok, token1} = TokenStore.find(scopes, sub1)
     {:ok, token2} = TokenStore.find(scopes, sub2)
+    assert token1 != token2
+  end
+
+  test "tokens with same scopes and subs but with different accounts are stored separately" do
+    scopes = "helloworld"
+    sub = "person@example.com"
+    account1 = "account1@example.com"
+    account2 = "account2@example.com"
+
+    TokenStore.store({account1, scopes}, %Token{
+      token: "123",
+      type: "Bearer",
+      sub: sub,
+      expires: :os.system_time(:seconds) + 1000,
+      account: account1
+    })
+
+    TokenStore.store({account2, scopes}, %Token{
+      token: "123",
+      type: "Bearer",
+      sub: sub,
+      expires: :os.system_time(:seconds) + 1000,
+      account: account2
+    })
+
+    assert :error == TokenStore.find(scopes, sub)
+    {:ok, %Token{account: ^account1} = token1} = TokenStore.find({account1, scopes}, sub)
+    {:ok, %Token{account: ^account2} = token2} = TokenStore.find({account2, scopes}, sub)
     assert token1 != token2
   end
 end

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -3,50 +3,125 @@ defmodule Goth.TokenTest do
   alias Goth.Token
 
   setup do
-    bypass = Bypass.open
+    bypass = Bypass.open()
     Application.put_env(:goth, :endpoint, "http://localhost:#{bypass.port}")
     Application.put_env(:goth, :token_source, :oauth)
     {:ok, bypass: bypass}
   end
 
   test "it can generate from response JSON" do
-    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json =
+      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+
     assert %Token{
-      token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
-      type: "Bearer",
-      expires: _exp
-    } = Token.from_response_json("scope", json)
+             token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
+             type: "Bearer",
+             expires: _exp
+           } = Token.from_response_json("scope", json)
   end
 
   test "it can generate from response JSON with sub" do
-    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json =
+      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+
     assert %Token{
-      token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
-      type: "Bearer",
-      sub: "sub@example.com",
-      expires: _exp
-    } = Token.from_response_json("scope", "sub@example.com", json)
+             token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
+             type: "Bearer",
+             sub: "sub@example.com",
+             expires: _exp,
+             account: :default
+           } = Token.from_response_json("scope", "sub@example.com", json)
+  end
+
+  test "it can generate from response JSON with sub and account" do
+    json =
+      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+
+    assert %Token{
+             token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
+             type: "Bearer",
+             sub: "sub@example.com",
+             expires: _exp,
+             account: "account"
+           } = Token.from_response_json({"account", "scope"}, "sub@example.com", json)
   end
 
   test "it calculates the expiration from the expires_in attr" do
-    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json =
+      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+
     token = Token.from_response_json("my-scope", json)
     assert token.expires > :os.system_time(:seconds) + 3000
   end
 
   test "it will pull a token from the API the first time", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
 
-     assert {:ok, %Token{token: "123"}} = Token.for_scope("random")
-     assert {:ok, %Token{token: "123"}} = Token.for_scope("random", "sub@example.com")
+    assert {:ok, %Token{token: "123", account: :default}} = Token.for_scope("random")
+
+    assert {:ok, %Token{token: "123", account: :default}} =
+             Token.for_scope("random", "sub@example.com")
+  end
+
+  test "it will pull a token for a specific account", %{bypass: bypass} do
+    # The test configuration sets an example JSON blob. We override it briefly
+    # during this test.
+    current_json = Application.get_env(:goth, :json)
+    new_json = "test/data/test-multicredentials.json" |> Path.expand() |> File.read!()
+
+    Application.put_env(:goth, :json, new_json, persistent: true)
+    Application.stop(:goth)
+
+    Application.start(:goth)
+
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
+
+    assert {:ok,
+            %Token{
+              token: "123",
+              account: "test-multicredentials-1@my-project.iam.gserviceaccount.com"
+            }} =
+             Token.for_scope(
+               {"test-multicredentials-1@my-project.iam.gserviceaccount.com", "random"}
+             )
+
+    assert {:ok,
+            %Token{
+              token: "123",
+              account: "test-multicredentials-1@my-project.iam.gserviceaccount.com"
+            }} =
+             Token.for_scope(
+               {"test-multicredentials-1@my-project.iam.gserviceaccount.com", "random"},
+               "sub@example.com"
+             )
+
+    # Restore original config
+    Application.put_env(:goth, :json, current_json, persistent: true)
+    System.delete_env("GOOGLE_APPLICATION_CREDENTIALS")
+    Application.stop(:goth)
+    Application.start(:goth)
   end
 
   test "it will pull a token from the token store if cached", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
 
     assert {:ok, %Token{token: access_token}} = Token.for_scope("another-random")
     assert access_token != nil
@@ -56,34 +131,60 @@ defmodule Goth.TokenTest do
     assert {:ok, %Token{token: ^access_token}} = Token.for_scope("another-random")
   end
 
-  test "it will pull a token from the token store if cached when sub is provided", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+  test "it will pull a token from the token store if cached when sub is provided", %{
+    bypass: bypass
+  } do
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
 
-    assert {:ok, %Token{token: access_token}} = Token.for_scope("another-random-sub", "sub@example.com")
+    assert {:ok, %Token{token: access_token}} =
+             Token.for_scope("another-random-sub", "sub@example.com")
+
     assert access_token != nil
 
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "123-sub", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{
+          "access_token" => "123-sub",
+          "token_type" => "Bearer",
+          "expires_in" => 3600
+        })
+      )
+    end)
 
-    assert {:ok, %Token{token: ^access_token}} = Token.for_scope("another-random-sub", "sub@example.com")
+    assert {:ok, %Token{token: ^access_token}} =
+             Token.for_scope("another-random-sub", "sub@example.com")
+
     {:ok, %Token{token: access_token_2}} = Token.for_scope("another-random-sub")
     assert access_token != access_token_2
   end
 
   test "refreshing a token hits the API", %{bypass: bypass} do
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "123", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
 
     assert {:ok, token} = Token.for_scope("first")
     assert token.token != nil
 
-    Bypass.expect bypass, fn conn ->
-      Plug.Conn.resp(conn, 201, Poison.encode!(%{"access_token" => "321", "token_type" => "Bearer", "expires_in" => 3600}))
-    end
+    Bypass.expect(bypass, fn conn ->
+      Plug.Conn.resp(
+        conn,
+        201,
+        Poison.encode!(%{"access_token" => "321", "token_type" => "Bearer", "expires_in" => 3600})
+      )
+    end)
 
     assert {:ok, %Token{token: at2}} = Token.refresh!(token)
     assert token.token != at2


### PR DESCRIPTION
This allows the user to use goth with multiple service accounts stored in one JSON credentials file (#35).

The auto-formatter from Elixir 1.6 changed the format of the files, I hope that's OK.