### PR TITLE
dynamically add account configs

### DIFF
--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -87,6 +87,11 @@ defmodule Goth.Config do
     |> Enum.into(%{})
   end
 
+  def add_config(config) when is_map(config) do
+    config = set_token_source(config)
+    GenServer.call(__MODULE__, {:add_config, config["client_email"], config})
+  end
+
   defp config_mod_init(config) do
     case Keyword.get(config, :config_module) do
       nil ->
@@ -229,6 +234,10 @@ defmodule Goth.Config do
 
   def handle_call({:set, account, key, value}, _from, keys) do
     {:reply, :ok, put_in(keys, [account, key], value)}
+  end
+
+  def handle_call({:add_config, account, config}, _from, keys) do
+    {:reply, :ok, Map.put(keys, account, config)}
   end
 
   def handle_call({:get, account, key}, _from, keys) do


### PR DESCRIPTION
While using this module for an application, a use-case came up to dynamically add service users (defined at runtime by using admin APIs). I do not believe any of the existing config definition methods allow this, so I went ahead and added a function to allow this in the Config module.

Let me know if there is a preferable implementation here, or an existing way to get the same functionality.