### PR TITLE
Allow for disabling Goth in your config

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ Alternatively, you can pass your sub email on a per-call basis, for example:
                        "some-email@your-domain.com")
   ```
 
+If you need to disable Goth in certain environments, you can set a `disabled`
+flag in your config:
+
+  ```elixir
+  config :goth,
+    disabled: true
+  ```
+
+This initializes Goth with an empty config, so any attempts to actually generate
+tokens will fail.
+
 ## Usage
 
 ### Retrieve a token:

--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -47,20 +47,32 @@ defmodule Goth.Config do
   end
 
   def init(:ok) do
-    {:ok, dynamic_config} =
-      Application.get_all_env(:goth)
-      |> config_mod_init
+    {:ok, config} =
+      :goth
+      |> Application.get_all_env()
+      |> config_mod_init()
 
+    config
+    |> Keyword.pop(:disabled, false)
+    |> load_and_init()
+  end
+
+  # We have been configured as `disabled` so just start with an empty configuration
+  defp load_and_init({true, _config}) do
+    {:ok, %{}}
+  end
+
+  defp load_and_init({false, app_config}) do
     config =
-      from_json(dynamic_config) || from_config(dynamic_config) || from_creds_file(dynamic_config) ||
-        from_gcloud_adc(dynamic_config) || from_metadata(dynamic_config)
+      from_json(app_config) || from_config(app_config) || from_creds_file(app_config) ||
+        from_gcloud_adc(app_config) || from_metadata(app_config)
 
     config =
       config
       |> map_config()
       |> Enum.map(fn {account, config} ->
-        actor_email = Keyword.get(dynamic_config, :actor_email)
-        project_id = determine_project_id(config, dynamic_config)
+        actor_email = Keyword.get(app_config, :actor_email)
+        project_id = determine_project_id(config, app_config)
 
         {
           account,

--- a/test/goth/config_test.exs
+++ b/test/goth/config_test.exs
@@ -65,6 +65,23 @@ defmodule Goth.ConfigTest do
     assert {:ok, :oauth_jwt} == Config.get(:token_source)
   end
 
+  test "Config can start up with no config when disabled" do
+    saved_config = Application.get_all_env(:goth)
+    try do
+      [:json, :metadata_url, :config_root_dir]
+      |> Enum.each(&Application.delete_env(:goth, &1))
+      Application.put_env(:goth, :disabled, true, persistent: true)
+
+      {:ok, pid} = GenServer.start_link(Goth.Config, :ok)
+      assert Process.alive?(pid)
+    after
+      Application.delete_env(:goth, :disabled)
+      Enum.each(saved_config, fn {k, v} ->
+        Application.put_env(:goth, k, v, persistent: true)
+      end)
+    end
+  end
+
   test "Goth correctly retrieves project IDs from metadata", %{bypass: bypass} do
     # The test configuration sets an example JSON blob. We override it briefly
     # during this test.


### PR DESCRIPTION
E.g. when your dev mode doesn't require access to GCS and you therefore don't
have a valid service account configuration avaliable.
