### PR TITLE
CI: Add new Elixir and Erlang/OTP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,32 @@ elixir:
   - 1.6
   - 1.7
   - 1.8
+  - 1.9
+  - 1.10
 otp_release:
   - 19.0
   - 20.0
   - 21.0
+  - 22.0
 matrix:
   exclude:
   - elixir: 1.4
     otp_release: 21.0
+  - elixir: 1.4
+    otp_release: 22.0
   - elixir: 1.5
     otp_release: 21.0
+  - elixir: 1.5
+    otp_release: 22.0
+  - elixir: 1.6
+    otp_release: 21.0
+  - elixir: 1.6
+    otp_release: 22.0
   - elixir: 1.8
     otp_release: 19.0
+  - elixir: 1.9
+    otp_release: 19.0
+  - elixir: 1.10
+    otp_release: 19.0
+  - elixir: 1.10
+    otp_release: 20.0


### PR DESCRIPTION
💁 Adds the following versions to the CI build matrix:
* Erlang/OTP: 22.0
* Elixir: 1.9, 1.10

I've added exclusions to this build matrix based on the Elixir <> Erlang/OTP compatibility information provided in https://hexdocs.pm/elixir/compatibility-and-deprecations.html#compatibility-between-elixir-and-erlang-otp.