### PR TITLE
Remove the `warnings_as_errors` compiler option

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,6 @@ defmodule Goth.Mixfile do
       description: description(),
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixirc_options: [warnings_as_errors: true],
       elixir: "~> 1.4",
       deps: deps()
     ]


### PR DESCRIPTION
This will enable newer versions of Elixir to run the tests and pass. While warnings should probably be resolved, many of them exist in underlying dependencies, and should therefore not fail the suite.