### PR TITLE
Add another fallback to use the quota project from a credentials file

### DIFF
--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -171,7 +171,7 @@ defmodule Goth.Config do
   defp determine_project_id(config, dynamic_config) do
     case Keyword.get(dynamic_config, :project_id) || System.get_env("GOOGLE_CLOUD_PROJECT") ||
            System.get_env("GCLOUD_PROJECT") || System.get_env("DEVSHELL_PROJECT_ID") ||
-           config["project_id"] do
+           config["project_id"] || config["quota_project_id"] do
       nil ->
         try do
           Client.retrieve_metadata_project()


### PR DESCRIPTION
This is to support use cases where a developer has used `gcloud auth
application-default login` and `gcloud auth application-default
set-quota-project $PROJECT_ID` and expects applications to use those
configuration values as a result.