### PR TITLE
Goth.Token recognize OAuth ID token responses

### DIFF
--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -127,10 +127,8 @@ defmodule Goth.Token do
     scopes = Keyword.get(options, :scopes, @default_scopes)
     jwt_scope = Enum.join(scopes, " ")
 
-    claims =
-      [{"scope", jwt_scope}, {"sub", sub}]
-      |> Enum.reject(fn {_, v} -> is_nil(v) end)
-      |> Enum.into(%{})
+claims = %{"scope" => jwt_scope}
+claims = if sub, do: Map.put(claims, "sub", sub), else: claims
 
     jwt = jwt_encode(claims, credentials)
 
@@ -226,7 +224,7 @@ defmodule Goth.Token do
     }
   end
 
-  defp build_token(%{"id_token" => "" <> _ = jwt}) do
+  defp build_token(%{"id_token" => jwt}) when is_binary(jwt) do
     %JOSE.JWT{fields: fields} = JOSE.JWT.peek_payload(jwt)
 
     %__MODULE__{


### PR DESCRIPTION
I've found a workaround for the `target_audience` claim required by Google Cloud Functions: the same effect can be achieved with the `scope` JWT claim.

With that in mind, the only change required was to handle the OAuth ID response.