### PR TITLE
Use Registry to register Goth servers

### DIFF
--- a/lib/goth.ex
+++ b/lib/goth.ex
@@ -28,7 +28,7 @@ defmodule Goth do
 
   ## Options
 
-    * `:name` - the name to register the server under.
+    * `:name` - a unique name to register the server under. It can be any term.
 
     * `:source` - the source to retrieve the token from.
 

--- a/lib/legacy/application.ex
+++ b/lib/legacy/application.ex
@@ -7,7 +7,11 @@ defmodule Goth.Application do
     envs = Application.get_all_env(:goth)
 
     if envs == [] do
-      Supervisor.start_link([], strategy: :one_for_one)
+      children = [
+        {Registry, keys: :unique, name: Goth.Registry}
+      ]
+
+      Supervisor.start_link(children, strategy: :one_for_one)
     else
       Goth.Supervisor.start_link(envs)
     end

--- a/lib/legacy/supervisor.ex
+++ b/lib/legacy/supervisor.ex
@@ -13,7 +13,8 @@ defmodule Goth.Supervisor do
   def init(envs) do
     children = [
       {Config, envs},
-      TokenStore
+      TokenStore,
+      {Registry, keys: :unique, name: Goth.Registry}
     ]
 
     Supervisor.init(children, strategy: :one_for_one)


### PR DESCRIPTION
Hi @peburrows 

I'd tried to complete https://github.com/peburrows/goth/issues/82#issuecomment-849894699

Just one thing that is not properly handled is how we start the Registry process as part of the supervision tree of the library, as `Goth.Application` module is already defined on the legacy folder, I wasn't able to provide a better solution sorry about it.