### PR TITLE
Self-signed JWT claim overrides

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+[
+  line_length: 120,
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -110,7 +110,7 @@ defmodule Goth.Token do
   for more information on metadata server.
   """
   @doc since: "1.3.0"
-  @spec fetch(map()) :: {:ok, t()} | {:error, Exception.t}
+  @spec fetch(map()) :: {:ok, t()} | {:error, Exception.t()}
   def fetch(config) when is_map(config) do
     config =
       Map.put_new_lazy(config, :http_client, fn ->
@@ -127,8 +127,8 @@ defmodule Goth.Token do
     scopes = Keyword.get(options, :scopes, @default_scopes)
     jwt_scope = Enum.join(scopes, " ")
 
-claims = %{"scope" => jwt_scope}
-claims = if sub, do: Map.put(claims, "sub", sub), else: claims
+    claims = %{"scope" => jwt_scope}
+    claims = if sub, do: Map.put(claims, "sub", sub), else: claims
 
     jwt = jwt_encode(claims, credentials)
 

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -52,9 +52,10 @@ defmodule Goth.Token do
     * `:url` - the URL of the authentication service, defaults to:
       `"https://www.googleapis.com/oauth2/v4/token"`
 
-    * `:scopes` - the list of token scopes, defaults to `#{inspect(@default_scopes)}`
+    * `:scopes` - the list of token scopes, defaults to `#{inspect(@default_scopes)}` (ignored if `:claims` present)
 
-    * `:sub` - an email of user being impersonated, defaults to `nil`
+    * `:claims` - self-signed JWT extra claims. Should be a map with string keys only.
+      A self-signed JWT will be [exchanged for a Google-signed ID token](https://cloud.google.com/functions/docs/securing/authenticating#exchanging_a_self-signed_jwt_for_a_google-signed_id_token)
 
   #### Refresh token - `{:refresh_token, credentials, options}`
 
@@ -91,6 +92,20 @@ defmodule Goth.Token do
 
       gcloud iam service-accounts keys create --key-file-type=json --iam-account=... credentials.json
 
+  #### Generate a cloud function invocation token using a service account credentials file:
+
+      iex> credentials = "credentials.json" |> File.read!() |> Jason.decode!()
+      ...> claims = %{"target_audience" => "https://<GCP_REGION>-<PROJECT_ID>.cloudfunctions.net/<CLOUD_FUNCTION_NAME>"}
+      ...> Goth.Token.fetch(%{source: {:service_account, credentials, [claims: claims]}})
+      {:ok, %Goth.Token{...}}
+
+  #### Generate an impersonated token using a service account credentials file:
+
+      iex> credentials = "credentials.json" |> File.read!() |> Jason.decode!()
+      ...> claims = %{"sub" => "<IMPERSONATED_ACCOUNT_EMAIL>"}
+      ...> Goth.Token.fetch(%{source: {:service_account, credentials, [claims: claims]}})
+      {:ok, %Goth.Token{...}}
+
   #### Retrieve the token using a refresh token:
 
       iex> credentials = "credentials.json" |> File.read!() |> Jason.decode!()
@@ -123,12 +138,15 @@ defmodule Goth.Token do
   defp request(%{source: {:service_account, credentials, options}} = config)
        when is_map(credentials) and is_list(options) do
     url = Keyword.get(options, :url, @default_url)
-    sub = Keyword.get(options, :sub)
-    scopes = Keyword.get(options, :scopes, @default_scopes)
-    jwt_scope = Enum.join(scopes, " ")
 
-    claims = %{"scope" => jwt_scope}
-    claims = if sub, do: Map.put(claims, "sub", sub), else: claims
+    claims =
+      Keyword.get_lazy(options, :claims, fn ->
+        scope = options |> Keyword.get(:scopes, @default_scopes) |> Enum.join(" ")
+        %{"scope" => scope}
+      end)
+
+    unless claims |> Map.keys() |> Enum.all?(&is_binary/1),
+      do: raise("expected service account claims to be a map with string keys, got a map: #{inspect(claims)}")
 
     jwt = jwt_encode(claims, credentials)
 
@@ -136,13 +154,16 @@ defmodule Goth.Token do
     grant_type = "urn:ietf:params:oauth:grant-type:jwt-bearer"
     body = "grant_type=#{grant_type}&assertion=#{jwt}"
 
-    result =
-      Goth.HTTPClient.request(config.http_client, :post, url, headers, body, [])
-      |> handle_response()
+    response = Goth.HTTPClient.request(config.http_client, :post, url, headers, body, [])
 
-    case result do
-      {:ok, token} -> {:ok, %{token | scope: jwt_scope, sub: sub || token.sub}}
-      {:error, error} -> {:error, error}
+    case handle_response(response) do
+      {:ok, token} ->
+        sub = Map.get(claims, "sub", token.sub)
+        scope = Map.get(claims, "scope", token.scope)
+        {:ok, %{token | scope: scope, sub: sub}}
+
+      {:error, error} ->
+        {:error, error}
     end
   end
 

--- a/lib/legacy/config.ex
+++ b/lib/legacy/config.ex
@@ -179,10 +179,9 @@ defmodule Goth.Config do
         rescue
           e ->
             if e.message =~ ":nxdomain" do
-                raise " Failed to retrieve project data from GCE internal metadata service.
+              raise " Failed to retrieve project data from GCE internal metadata service.
                    Either you haven't configured your GCP credentials, you aren't running on GCE, or both.
                    Please see README.md for instructions on configuring your credentials."
-
             else
               reraise e, __STACKTRACE__
             end

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -5,16 +5,13 @@ defmodule Goth.TokenTest do
     bypass = Bypass.open()
 
     Bypass.expect(bypass, fn conn ->
-      body =
-        ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
+      body = ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
 
       Plug.Conn.resp(conn, 200, body)
     end)
 
     config = %{
-      source:
-        {:service_account, random_service_account_credentials(),
-         url: "http://localhost:#{bypass.port}"}
+      source: {:service_account, random_service_account_credentials(), url: "http://localhost:#{bypass.port}"}
     }
 
     {:ok, token} = Goth.Token.fetch(config)
@@ -26,8 +23,7 @@ defmodule Goth.TokenTest do
     bypass = Bypass.open()
 
     Bypass.expect(bypass, fn conn ->
-      body =
-        ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
+      body = ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
 
       Plug.Conn.resp(conn, 200, body)
     end)
@@ -35,8 +31,7 @@ defmodule Goth.TokenTest do
     config = %{
       source:
         {:service_account, random_service_account_credentials(),
-          url: "http://localhost:#{bypass.port}",
-          sub: "bob@example.com"}
+         url: "http://localhost:#{bypass.port}", sub: "bob@example.com"}
     }
 
     {:ok, token} = Goth.Token.fetch(config)
@@ -49,8 +44,7 @@ defmodule Goth.TokenTest do
     bypass = Bypass.open()
 
     Bypass.expect(bypass, fn conn ->
-      body =
-        ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
+      body = ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
 
       Plug.Conn.resp(conn, 200, body)
     end)
@@ -84,8 +78,7 @@ defmodule Goth.TokenTest do
       "sub" => "110725120108142672649"
     }
 
-    jwt =
-      JOSE.JWS.sign(jwk_es256, Jason.encode!(payload), header) |> JOSE.JWS.compact() |> elem(1)
+    jwt = JOSE.JWS.sign(jwk_es256, Jason.encode!(payload), header) |> JOSE.JWS.compact() |> elem(1)
 
     Bypass.expect(bypass, fn conn ->
       body = ~s|{"id_token":"#{jwt}"}|
@@ -118,9 +111,7 @@ defmodule Goth.TokenTest do
     end)
 
     config = %{
-      source:
-        {:service_account, random_service_account_credentials(),
-         url: "http://localhost:#{bypass.port}"}
+      source: {:service_account, random_service_account_credentials(), url: "http://localhost:#{bypass.port}"}
     }
 
     {:error, %Jason.DecodeError{}} = Goth.Token.fetch(config)
@@ -134,16 +125,14 @@ defmodule Goth.TokenTest do
     bypass = Bypass.open()
 
     Bypass.expect(bypass, fn conn ->
-      body =
-        ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
+      body = ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
 
       Plug.Conn.resp(conn, 200, body)
     end)
 
     config = %{
       source:
-        {:refresh_token,
-         %{"client_id" => "aaa", "client_secret" => "bbb", "refresh_token" => "ccc"},
+        {:refresh_token, %{"client_id" => "aaa", "client_secret" => "bbb", "refresh_token" => "ccc"},
          url: "http://localhost:#{bypass.port}"}
     }
 

--- a/test/goth_test.exs
+++ b/test/goth_test.exs
@@ -12,9 +12,7 @@ defmodule GothTest do
 
     config = [
       name: test,
-      source:
-        {:service_account, random_service_account_credentials(),
-         url: "http://localhost:#{bypass.port}"}
+      source: {:service_account, random_service_account_credentials(), url: "http://localhost:#{bypass.port}"}
     ]
 
     start_supervised!({Goth, config})
@@ -41,9 +39,7 @@ defmodule GothTest do
 
     Goth.Server.start_link(
       name: test,
-      source:
-        {:service_account, random_service_account_credentials(),
-         url: "http://localhost:#{bypass.port}"},
+      source: {:service_account, random_service_account_credentials(), url: "http://localhost:#{bypass.port}"},
       http_client: {Goth.HTTPClient.Hackney, []},
       retry_after: 10
     )
@@ -53,8 +49,7 @@ defmodule GothTest do
     assert_receive :pong, 1000
     assert_receive :pong, 1000
 
-    assert_receive {:EXIT, _,
-                    {%RuntimeError{message: "too many failed attempts to refresh" <> _}, _}},
+    assert_receive {:EXIT, _, {%RuntimeError{message: "too many failed attempts to refresh" <> _}, _}},
                    1000
   end
 
@@ -70,9 +65,7 @@ defmodule GothTest do
 
     config = [
       name: test,
-      source:
-        {:service_account, random_service_account_credentials(),
-         url: "http://localhost:#{bypass.port}"},
+      source: {:service_account, random_service_account_credentials(), url: "http://localhost:#{bypass.port}"},
       retries: 0
     ]
 

--- a/test/legacy/token_test.exs
+++ b/test/legacy/token_test.exs
@@ -10,8 +10,7 @@ defmodule Goth.Legacy.TokenTest do
   end
 
   test "it can generate from response JSON" do
-    json =
-      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
 
     assert %Token{
              token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
@@ -21,8 +20,7 @@ defmodule Goth.Legacy.TokenTest do
   end
 
   test "it can generate from response JSON with sub" do
-    json =
-      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
 
     assert %Token{
              token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
@@ -34,8 +32,7 @@ defmodule Goth.Legacy.TokenTest do
   end
 
   test "it can generate from response JSON with sub and account" do
-    json =
-      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
 
     assert %Token{
              token: "1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M",
@@ -47,8 +44,7 @@ defmodule Goth.Legacy.TokenTest do
   end
 
   test "it calculates the expiration from the expires_in attr" do
-    json =
-      ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
+    json = ~s({"token_type":"Bearer","expires_in":3600,"access_token":"1/8xbJqaOZXSUZbHLl5EOtu1pxz3fmmetKx9W8CV4t79M"})
 
     token = Token.from_response_json("my-scope", json)
     assert token.expires > :os.system_time(:seconds) + 3000
@@ -65,8 +61,7 @@ defmodule Goth.Legacy.TokenTest do
 
     assert {:ok, %Token{token: "123", account: :default}} = for_scope("random")
 
-    assert {:ok, %Token{token: "123", account: :default}} =
-             for_scope("random", "sub@example.com")
+    assert {:ok, %Token{token: "123", account: :default}} = for_scope("random", "sub@example.com")
   end
 
   test "it will not raise when token cannot be retrieved from the API" do
@@ -99,10 +94,7 @@ defmodule Goth.Legacy.TokenTest do
             %Token{
               token: "123",
               account: "test-multicredentials-1@my-project.iam.gserviceaccount.com"
-            }} =
-             for_scope(
-               {"test-multicredentials-1@my-project.iam.gserviceaccount.com", "random"}
-             )
+            }} = for_scope({"test-multicredentials-1@my-project.iam.gserviceaccount.com", "random"})
 
     assert {:ok,
             %Token{
@@ -161,13 +153,11 @@ defmodule Goth.Legacy.TokenTest do
       )
     end)
 
-    assert {:ok, %Token{token: access_token}} =
-             for_scope("another-random-sub", "sub@example.com")
+    assert {:ok, %Token{token: access_token}} = for_scope("another-random-sub", "sub@example.com")
 
     assert access_token != nil
 
-    assert {:ok, %Token{token: ^access_token}} =
-             for_scope("another-random-sub", "sub@example.com")
+    assert {:ok, %Token{token: ^access_token}} = for_scope("another-random-sub", "sub@example.com")
 
     {:ok, %Token{token: access_token_2}} = for_scope("another-random-sub")
     assert access_token != access_token_2


### PR DESCRIPTION
This PR allows overriding self-signed JWT claims. Which in turn makes it easier to follow different token exchange scenarios:

### Cloud function invocation token [(read more)](https://cloud.google.com/functions/docs/securing/authenticating#exchanging_a_self-signed_jwt_for_a_google-signed_id_token)

```
iex> credentials = "credentials.json" |> File.read!() |> Jason.decode!()
...> claims = %{"target_audience" => "https://<GCP_REGION>-<PROJECT_ID>.cloudfunctions.net/<CLOUD_FUNCTION_NAME>"}
...> Goth.Token.fetch(%{source: {:service_account, credentials, [claims: claims]}})
{:ok, %Goth.Token{...}}
```

### Impersonating account

```
iex> credentials = "credentials.json" |> File.read!() |> Jason.decode!()
...> claims = %{"sub" => "<IMPERSONATED_ACCOUNT_EMAIL>"}
...> Goth.Token.fetch(%{source: {:service_account, credentials, [claims: claims]}})
{:ok, %Goth.Token{...}}
```