### PR TITLE
config http client in goth module

### DIFF
--- a/lib/goth.ex
+++ b/lib/goth.ex
@@ -88,6 +88,10 @@ defmodule Goth do
     opts
     |> Keyword.put_new(:retry_after, @retry_after)
     |> Keyword.put_new(:refresh_before, @refresh_before_minutes * 60)
-    |> Keyword.put_new(:http_client, {Goth.HTTPClient.Hackney, []})
+    |> Keyword.put_new(:http_client, http_client())
+  end
+
+  defp http_client do
+    Application.get_env(Goth, :http_client, {Goth.HTTPClient.Hackney, []})
   end
 end

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -114,7 +114,10 @@ defmodule Goth.Token do
   def fetch(config) when is_map(config) do
     config =
       Map.put_new_lazy(config, :http_client, fn ->
-        Goth.HTTPClient.init({Goth.HTTPClient.Hackney, []})
+        case Application.get_env(Goth, :http_client) do
+          nil -> Goth.HTTPClient.init({Goth.HTTPClient.Hackney, []})
+          http_client -> Goth.HTTPClient.init(http_client)
+        end
       end)
 
     request(config)


### PR DESCRIPTION
With this change, it will be possible to define an HTTP client for `Goth.Token.fetch` using config,

```elixir
Application.put_env(Goth, :http_client, {MyMockClient, []})
```