### PR TITLE
Feat: retrieve identity token from `metadata`

### DIFF
--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -217,7 +217,7 @@ defmodule Goth.Token do
   end
 
   defp handle_jwt_response({:ok, %{status: 200, body: body}}) do
-    handle_response({:ok, %{status: 200, body: %{"id_token" => body}}})
+    {:ok, build_token(%{"id_token" => body})}
   end
 
   defp handle_response({:ok, %{status: 200, body: body}}) do

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -220,6 +220,8 @@ defmodule Goth.Token do
     {:ok, build_token(%{"id_token" => body})}
   end
 
+  defp handle_jwt_response(response), do: handle_response(response)
+
   defp handle_response({:ok, %{status: 200, body: body}}) do
     case Jason.decode(body) do
       {:ok, attrs} -> {:ok, build_token(attrs)}

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -211,6 +211,8 @@ defmodule Goth.Token do
   end
 
   defp handle_response({:ok, %{status: 200, body: body}}) do
+    IO.puts(inspect(body, pretty: true))
+
     case Jason.decode(body) do
       {:ok, attrs} -> {:ok, build_token(attrs)}
       {:error, reason} -> {:error, reason}


### PR DESCRIPTION
I do not know if this feature is out of scope since **Goth** first purpose is to _generate and retrieve OAuth2 tokens_ but I'll give it a shot.

This pull request aim to integrate a feature that will provide users a way to fetch a service account _identity token_ from **metadata** as it is actually possible for _access tokens_.

Following Google documentation about [VM instance metadata](https://cloud.google.com/compute/docs/metadata/default-metadata-values#vm_instance_metadata), we can retrieve a JSON Web Token from **metadata** using the `identity` entry with an audience parameter. (eg. `identity?audience=http://www.example.com`)

The idea would be to add an other option called `:audience` when using **metadata** as source.

```elixir
id = MyApp.Goth
audience = "xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com"
source = {:metadata, audience: audience}
Supervisor.child_spec({Goth, name: id, source: source}, id: id)
```

If this option is present, we know that we shouldn't query for an access token but for an identity token.

```elixir
iex> {:ok, token} = Goth.fetch(MyApp.Goth)
iex> token
%Goth.Token{
  scope: "xxxxxxxxxxxxx-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx.apps.googleusercontent.com",
  token: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c",
  type: "Bearer",
  expires: 1453356568,
  ...
}
```