### PR TITLE
Add pattern matching when body is already a map

### DIFF
--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -273,6 +273,10 @@ defmodule Goth.Token do
 
   defp handle_jwt_response(response), do: handle_response(response)
 
+  defp handle_response({:ok, %{status: 200, body: body}}) when is_map(body) do
+    {:ok, build_token(body)}
+  end
+
   defp handle_response({:ok, %{status: 200, body: body}}) do
     case Jason.decode(body) do
       {:ok, attrs} -> {:ok, build_token(attrs)}


### PR DESCRIPTION
I've found this when trying to use the `http_client: &Req.request/1` option, because the body was already decoded by [`Req`](https://github.com/wojtekmach/req)

```elixir

  * 1st argument: not an iodata term

    :erlang.iolist_to_binary(%{"access_token" => "...", "expires_in" => 3599, "token_type" => "Bearer"})
    (jason 1.3.0) lib/jason.ex:69: Jason.decode/2
    (goth 1.3.0-rc.4) lib/goth/token.ex:277: Goth.Token.handle_response/1
    (goth 1.3.0-rc.4) lib/goth/token.ex:213: Goth.Token.request/1
    (goth 1.3.0-rc.4) lib/goth.ex:213: Goth.prefetch/1
    (goth 1.3.0-rc.4) lib/goth.ex:206: Goth.handle_continue/2
    (stdlib 3.17) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17) gen_server.erl:437: :gen_server.loop/7
Last message: {:continue, :async_prefetch}
```

With this PR, it solves the bug and we can use a HTTP Client that returns a decoded body