### PR TITLE
Fixed getting tokens from metadata with no options provided

### DIFF
--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -199,7 +199,7 @@ defmodule Goth.Token do
 
   #### Retrieve the token using the Google metadata server:
 
-      iex> Goth.Token.fetch(source: :metadata})
+      iex> Goth.Token.fetch(source: :metadata)
       {:ok, %Goth.Token{...}}
 
   See [Storing and retrieving instance metadata](https://cloud.google.com/compute/docs/storing-retrieving-metadata)
@@ -319,7 +319,7 @@ defmodule Goth.Token do
   end
 
   defp request(%{source: :metadata} = config) do
-    %{config | source: {:metadata, []}}
+    request(%{config | source: {:metadata, []}})
   end
 
   defp request(%{source: {:metadata, options}} = config) when is_list(options) do


### PR DESCRIPTION
A tiny fix for shorthand metadata source configuration:

`{Goth, name: MyApp.Goth}` - broken
`{Goth, name: MyApp.Goth, source: :metadata}` - broken
`{Goth, name: MyApp.Goth, source: {:metadata, []}}` - works

Got this issue while migrating my app from using credentials file to Workload Identity.

Stacktrace:

```
(CaseClauseError) no case clause matching: %Goth{http_client: {#Function<3.71762554/1 in Goth."-fun.__finch__/1-">, []}, max_retries: 10, name: MyApp.Goth, refresh_before: 300, retries: 0, retry_after: nil, retry_delay: #Function<4.71762554/1 in Goth."-fun.exp_backoff/1-">, source: {:metadata, []}}
    (goth 1.3.0) lib/goth.ex:194: Goth.prefetch/1
    (goth 1.3.0) lib/goth.ex:187: Goth.handle_continue/2
    (stdlib 3.17.2) gen_server.erl:695: :gen_server.try_dispatch/4
    (stdlib 3.17.2) gen_server.erl:437: :gen_server.loop/7
    (stdlib 3.17.2) proc_lib.erl:226: :proc_lib.init_p_do_apply/3
Last message: {:continue, :async_prefetch}
```

I couldn't find a way to write a test for this with the current setup. I hope it's simple enough to go untested.


