### PR TITLE
New token fetch method for Huawei.

### DIFF
--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -172,6 +172,25 @@ defmodule Goth.TokenTest do
     assert token.scope == "dummy_scope"
   end
 
+  test "fetch/1 with client credentials" do
+    bypass = Bypass.open()
+
+    Bypass.expect(bypass, fn conn ->
+      body = ~s|{"access_token":"dummy","scope":"dummy_scope","expires_in":3599,"token_type":"Bearer"}|
+
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    config = %{
+      source:
+        {:client_credentials, %{"client_id" => "aaa", "client_secret" => "bbb"}, url: "http://localhost:#{bypass.port}"}
+    }
+
+    {:ok, token} = Goth.Token.fetch(config)
+    assert token.token == "dummy"
+    assert token.scope == "dummy_scope"
+  end
+
   test "fetch/1 from instance metadata" do
     bypass = Bypass.open()
 


### PR DESCRIPTION
This change allows using this library for Huawei OAuth 2.0-based Authentication, which is very similar to Google.

It defines a new config `client_credentials` that follows the documentation stated in https://developer.huawei.com/consumer/en/doc/development/HMSCore-Guides/oauth2-0000001212610981, using `client_id` and `client_secret`. It also includes by default the Huawei url.
