### PR TITLE
Use Logger.warning/2

### DIFF
--- a/lib/goth.ex
+++ b/lib/goth.ex
@@ -233,7 +233,7 @@ defmodule Goth do
   end
 
   defp start_http_client({module, _} = config) when is_atom(module) do
-    Logger.warn("Setting http_client: mod | {mod, opts} is deprecated in favour of http_client: fun | {fun, opts}")
+    Logger.warning("Setting http_client: mod | {mod, opts} is deprecated in favour of http_client: fun | {fun, opts}")
 
     Goth.HTTPClient.init(config)
   end

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Goth.Mixfile do
       version: @version,
       package: package(),
       elixirc_paths: elixirc_paths(Mix.env()),
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       source_url: @source_url,
       name: "Goth",
       description: description(),


### PR DESCRIPTION
Use Logger.warning/2, as Logger.warn/2 is deprecated.

Reference: https://hexdocs.pm/logger/main/Logger.html#warn/2