### PR TITLE
Fix deprecation warning with finch 0.17

### DIFF
--- a/lib/goth/application.ex
+++ b/lib/goth/application.ex
@@ -6,10 +6,20 @@ defmodule Goth.Application do
   def start(_type, _args) do
     children = [
       {Registry, keys: :unique, name: Goth.Registry},
-      {Finch, name: Goth.Finch, pools: %{default: [protocol: :http1]}},
+      {Finch, name: Goth.Finch, pools: %{default: finch_default_pool_opts()}},
       Goth.TokenStore
     ]
 
     Supervisor.start_link(children, strategy: :one_for_one, name: Goth.Supervisor)
+  end
+
+  defp finch_default_pool_opts do
+    finch_version = Application.spec(:finch, :vsn)
+
+    if Version.match?(List.to_string(finch_version), ">= 0.17.0") do
+      [protocols: [:http1]]
+    else
+      [protocol: :http1]
+    end
   end
 end


### PR DESCRIPTION
Finch 0.17 deprecated the `protocol` pool option: https://github.com/sneako/finch/commit/334af8efdcae2e38a47c5f572e4225f7cf04de1e