### PR TITLE
Handle cases when SDK config file is blank

### DIFF
--- a/lib/goth/config.ex
+++ b/lib/goth/config.ex
@@ -232,13 +232,14 @@ defmodule Goth.Config do
   end
 
   def get_configuration_data(configuration_file) do
-    if File.regular?(configuration_file) do
-      configuration_data = configuration_file |> File.read!() |> decode_ini()
-
-      # Only retrieve the required data.
-      %{"project_id" => configuration_data["core"]["project"], "actor_email" => configuration_data["core"]["account"]}
+    with true <- File.regular?(configuration_file),
+         configuration_data <- configuration_file |> File.read!() |> decode_ini(),
+         project_id when not is_nil(project_id) <- configuration_data["core"]["project"],
+         actor_email when not is_nil(actor_email) <- configuration_data["core"]["account"] do
+      %{"project_id" => project_id, "actor_email" => actor_email}
     else
-      nil
+      _ ->
+        nil
     end
   end
 

--- a/test/goth/config_test.exs
+++ b/test/goth/config_test.exs
@@ -150,6 +150,30 @@ defmodule Goth.ConfigTest do
     Application.start(:goth)
   end
 
+  test "Reading blank configuration should return nil" do
+    current_json = Application.get_env(:goth, :json)
+    Application.put_env(:goth, :json, nil, persistent: true)
+
+    current_config_root = Application.get_env(:goth, :config_root_dir)
+
+    config_root = Path.expand("test/data/home/gcloud")
+    Application.put_env(:goth, :config_root_dir, config_root)
+
+    Application.stop(:goth)
+    Application.start(:goth)
+
+    data =
+      Path.expand("test/data/home/gcloud/configurations/blank_config_default")
+      |> Config.get_configuration_data()
+
+    assert(data == nil)
+
+    Application.put_env(:goth, :config_root_dir, current_config_root, persistent: true)
+    Application.put_env(:goth, :json, current_json, persistent: true)
+    Application.stop(:goth)
+    Application.start(:goth)
+  end
+
   test "GOOGLE_APPLICATION_CREDENTIALS is read" do
     # The test configuration sets an example JSON blob. We override it briefly
     # during this test.


### PR DESCRIPTION
`gcloud` CLI config file, `~/. config/gcloud/configurations/config_default` could be blank if `gcloud init` is not run yet. In that case, `Goth.Config.get_configuration_data/1` still returns an empty map instead of `nil` so the fallover to fetching from metadata server would not work.