### PR TITLE
Support direct workload identity federation and more credential_source options

### DIFF
--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -402,9 +402,8 @@ defmodule Goth.Token do
 
   defp handle_workload_identity_response(
          {:ok, %{status: 200, body: body}},
-         %{source: {:workload_identity, credentials}} = config
+         %{source: {:workload_identity, %{"service_account_impersonation_url" => url}}} = config
        ) do
-    url = Map.get(credentials, "service_account_impersonation_url")
     %{"access_token" => token, "token_type" => type} = Jason.decode!(body)
 
     headers = [{"content-type", "text/json"}, {"Authorization", "#{type} #{token}"}]

--- a/lib/goth/token.ex
+++ b/lib/goth/token.ex
@@ -390,7 +390,20 @@ defmodule Goth.Token do
     {url, audience}
   end
 
-  defp subject_token_from_credential_source(%{"file" => file, "format" => %{"type" => "text"}}) do
+  defp subject_token_from_credential_source(%{"file" => file, "format" => format}) do
+    binary = File.read!(file)
+
+    case format do
+      %{"type" => "text"} ->
+        binary
+
+      %{"type" => "json", "subject_token_field_name" => field} ->
+        binary |> Jason.decode!() |> Map.fetch!(field)
+    end
+  end
+
+  # the default file type if not specified is "text"
+  defp subject_token_from_credential_source(%{"file" => file}) do
     File.read!(file)
   end
 

--- a/test/data/test-credentials-direct-workload-identity-json.json
+++ b/test/data/test-credentials-direct-workload-identity-json.json
@@ -1,7 +1,11 @@
 {
   "audience": "//iam.googleapis.com/projects/my-project/locations/global/workloadIdentityPools/my-cluster/providers/my-provider",
   "credential_source": {
-    "file": "test/data/workload-identity-token"
+    "file": "test/data/workload-identity-token.json",
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "token"
+    }
   },
   "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
   "token_url": "https://sts.googleapis.com/v1/token",

--- a/test/data/test-credentials-direct-workload-identity.json
+++ b/test/data/test-credentials-direct-workload-identity.json
@@ -1,0 +1,12 @@
+{
+  "audience": "//iam.googleapis.com/projects/my-project/locations/global/workloadIdentityPools/my-cluster/providers/my-provider",
+  "credential_source": {
+    "file": "test/data/workload-identity-token",
+    "format": {
+      "type": "text"
+    }
+  },
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "type": "external_account"
+}

--- a/test/data/workload-identity-token.json
+++ b/test/data/workload-identity-token.json
@@ -1,0 +1,3 @@
+{
+  "token": "workload-identity-token"
+}

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -252,6 +252,30 @@ defmodule Goth.TokenTest do
     assert token.scope == nil
   end
 
+  test "fetch/1 from direct workload identity, json format" do
+    token_bypass = Bypass.open()
+
+    Bypass.expect(token_bypass, fn conn ->
+      assert conn.request_path == "/v1/token"
+
+      body = ~s|{"access_token":"dummy","expires_in":599,"token_type":"Bearer"}|
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    credentials =
+      File.read!("test/data/test-credentials-direct-workload-identity-json.json")
+      |> Jason.decode!()
+      |> Map.put("token_url", "http://localhost:#{token_bypass.port}/v1/token")
+
+    config = %{
+      source: {:workload_identity, credentials}
+    }
+
+    {:ok, token} = Goth.Token.fetch(config)
+    assert token.token == "dummy"
+    assert token.scope == nil
+  end
+
   defp random_service_account_credentials do
     %{
       "private_key" => random_private_key(),

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -228,6 +228,30 @@ defmodule Goth.TokenTest do
     assert token.scope == nil
   end
 
+  test "fetch/1 from direct workload identity" do
+    token_bypass = Bypass.open()
+
+    Bypass.expect(token_bypass, fn conn ->
+      assert conn.request_path == "/v1/token"
+
+      body = ~s|{"access_token":"dummy","expires_in":599,"token_type":"Bearer"}|
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    credentials =
+      File.read!("test/data/test-credentials-direct-workload-identity.json")
+      |> Jason.decode!()
+      |> Map.put("token_url", "http://localhost:#{token_bypass.port}/v1/token")
+
+    config = %{
+      source: {:workload_identity, credentials}
+    }
+
+    {:ok, token} = Goth.Token.fetch(config)
+    assert token.token == "dummy"
+    assert token.scope == nil
+  end
+
   defp random_service_account_credentials do
     %{
       "private_key" => random_private_key(),


### PR DESCRIPTION
1. Direct workload identity federation does not require service account impersonation in order to exchange an access token. Commit 7219e27 adds support for direct access token exchange.
2. When given [file-sourced credentials][0], they may be in either text (default) or json format. When the json format is used, a subject_token_name_field must be present. Commit 2a30438 adds support for json credential sources as well as missing (default) format.



[0]: https://cloud.google.com/iam/docs/workload-identity-federation-with-other-providers#file-sourced-credentials