### PR TITLE
Support fetching subject token from url for workload identity

### DIFF
--- a/test/data/test-credentials-url-workload-identity.json
+++ b/test/data/test-credentials-url-workload-identity.json
@@ -1,0 +1,17 @@
+{
+  "audience": "//iam.googleapis.com/projects/my-project/locations/global/workloadIdentityPools/my-cluster/providers/my-provider",
+  "credential_source": {
+    "url": "",
+    "headers": {
+      "Authentication": "Bearer 123",
+      "X-Other": "things"
+    },
+    "format": {
+      "type": "json",
+      "subject_token_field_name": "token"
+    }
+  },
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "type": "external_account"
+}


### PR DESCRIPTION
Add the ability to fetch the `subject_token` for a workload identity from a url. Also added some documentation in `token.ex` for using `:workload_identity`. This allows us to use workload identity directly without any additional steps in our CI actions based on how we have configured workload identity.

I was able to get it working with the previous commits to `master` here, by making an additional `curl`, but with this we can just use the credentials json directly