### PR TITLE
Allow supplying ones own subject token for workload identities

### DIFF
--- a/test/data/test-credentials-workload-identity-subject-token.json
+++ b/test/data/test-credentials-workload-identity-subject-token.json
@@ -1,0 +1,7 @@
+{
+  "audience": "//iam.googleapis.com/projects/my-project/locations/global/workloadIdentityPools/my-cluster/providers/my-provider",
+  "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+  "subject_token": "token",
+  "token_url": "https://sts.googleapis.com/v1/token",
+  "type": "external_account"
+}

--- a/test/goth/token_test.exs
+++ b/test/goth/token_test.exs
@@ -276,6 +276,30 @@ defmodule Goth.TokenTest do
     assert token.scope == nil
   end
 
+  test "fetch/1 from workload identity, subject_token supplied" do
+    token_bypass = Bypass.open()
+
+    Bypass.expect(token_bypass, fn conn ->
+      assert conn.request_path == "/v1/token"
+
+      body = ~s|{"access_token":"dummy","expires_in":599,"token_type":"Bearer"}|
+      Plug.Conn.resp(conn, 200, body)
+    end)
+
+    credentials =
+      File.read!("test/data/test-credentials-direct-workload-identity-json.json")
+      |> Jason.decode!()
+      |> Map.put("token_url", "http://localhost:#{token_bypass.port}/v1/token")
+
+    config = %{
+      source: {:workload_identity, credentials}
+    }
+
+    {:ok, token} = Goth.Token.fetch(config)
+    assert token.token == "dummy"
+    assert token.scope == nil
+  end
+
   test "fetch/1 from url-based workload identity" do
     token_bypass = Bypass.open()
     subject_token_bypass = Bypass.open()


### PR DESCRIPTION
In conjunction with #183 we found that if we wanted to use aws as a credential source for workload identities we either would have to implement a lot of aws access token signing, role handling, local vs in the cloud logic, etc stuff in this library which felt fairly overkill, or to just handle that logic in our own application.

Given our application has all the necessary libraries to handle aws credential fetching and signing, the logical choice seems to be to just handle it all on the caller side and pass the formatted subject_token directly into `Goth`.