### PR TITLE
Minor Cleanups

### DIFF
--- a/lib/goth.ex
+++ b/lib/goth.ex
@@ -260,7 +260,7 @@ defmodule Goth do
 
   defp handle_retry(exception, %{retries: retries, max_retries: max_retries} = state) when retries >= max_retries - 1 do
     Logger.error("too many failed attempts to refresh, last error: #{inspect(exception)}")
-    {:noreply, %{state | retries: 0}}
+    {:stop, {:shutdown, exception}, %{state | retries: 0}}
   end
 
   defp handle_retry(_, state) do


### PR DESCRIPTION
We needed two features currently not implemented:

1. A clean shutdown flow for goth processes
2. A start callback so we can manually manage goth within a custom supervisor

Both of these are due to our app requiring gcp credentials be provided by a user, so they cannot be able to be statically configured in the root application supervision tree (and there's an expectation that failure is common as well).